### PR TITLE
docs: setup Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,52 @@
+name: Bug Report
+description: Please add a short description of what is not working as intended.
+body:
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      description: Is this a production or development bug?
+      options:
+        - Production (https://sleepapi.azurewebsites.net/)
+        - Development (https://dev-sleepapi.azurewebsites.net/)
+        - Local (https://localhost:3000/)
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to Reproduce
+      description: Please add a detailed description of how we can reproduce the issue.
+      placeholder: |-
+        1. do this
+        2. then do this
+        3. finally do this
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+      description: Please add logs, screenshots and additional info here.
+    validations:
+      required: true
+  - type: input
+    id: link
+    attributes:
+      label: Link
+      placeholder: https://sleepapi.azurewebsites.net/production-calculator.html/...
+      description: If on Azure, where exactly did you find the bug?
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |-
+        ## Thank you! 🙏
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+
+contact_links:
+  - name: Discuss Sleep API
+    url: https://discord.gg/w97qFff8n4
+    about: You're welcome to join us on the Mathcord Discord server, we have a dedicated section.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,18 @@
+name: 💡 Feature Request
+description: A new feature request? So exciting!
+body:
+  - type: textarea
+    id: expected
+    attributes:
+      label: Details
+      description: Go ahead, dump your ideas in here!
+      placeholder: |-
+        Sleep API should make me my morning coffee..
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |-
+        ## Thank you! 🙏
+    validations:
+      required: false


### PR DESCRIPTION
**WHY**

To ease the barrier-of-entry for new contributors and provide the developers with clearer defined issue we'll set up some issue templates.

**WHAT**

Added bug and feature issue templates. Added the option to create blank issues without template. Added a direct link to Discord in case the contributor just wants to discuss the tool.