### PR TITLE
fix: tier-list image lookup case-sensitivity failure

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
 # Sleep API - Backend
 
-As explained in [Development Setup](../DEVELOPMENT_SETUP.md) you should now have Node installed with NVM and set up your development environment. We'll now talk about getting the backend up and running.
+As explained in [Development Setup](../DEVELOPMENT_SETUP.md) you should now have Node installed with NVM and set up your development environment. We'll now talk about getting the backend up and running. Start by installing the required node modules with `npm install` inside the backend folder.
 
 The backend also currently hosts the website you see on [Sleep API][sleepapi]
 

--- a/backend/src/assets/tier-lists.html
+++ b/backend/src/assets/tier-lists.html
@@ -250,7 +250,7 @@
           modalButton.style.overflow = 'hidden';
 
           var img = document.createElement('img');
-          img.src = `./pokemon/${pokemonWithDetails.pokemon}.png`;
+          img.src = `./pokemon/${pokemonWithDetails.pokemon.toLowerCase()}.png`;
           img.className = 'img-fluid';
           img.style.transform = 'scale(1.5)';
 


### PR DESCRIPTION
**WHY**

Looking up the static images used in the tier list failed on Linux OS as the images were looked up with all caps, but the names of the images were in lowercase. Linux is case-sensitive.

**WHAT**

Converted pokemon names to lowercase before looking up their images. Also added a drive-by npm install line in the backend README.