### PR TITLE
feat(api): change root path to /api

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -15,6 +15,7 @@ import TierlistController from './controllers/tierlist/tierlist.controller';
 import DatabaseMigration from './database/migration/database-migration';
 import DataSeed from './database/seed/data-seed';
 import swaggerDocument from './public/swagger.json';
+import { BaseRouter } from './routes/base-router';
 import { ProductionRouter } from './routes/calculator-router/production-router';
 import { HealthRouter } from './routes/health-router/health-router';
 import { MealRouter } from './routes/meal-router/meal-router';
@@ -51,6 +52,7 @@ async function main() {
   app.use(express.json());
   app.use(morgan('tiny'));
   app.use(cors(options));
+  app.use('/api', BaseRouter.router);
   app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument, { customSiteTitle: 'Sleep API' }));
   app.use(express.static(path.join(__dirname, 'assets')));
   app.get('/', (req: Request, res: Response) => {
@@ -63,13 +65,6 @@ async function main() {
   });
 
   // Register routes
-  app.use(HealthRouter.router);
-  app.use(MealRouter.router);
-  app.use(RankingRouter.router);
-  app.use(PokemonRouter.router);
-  app.use(OptimalCombinationRouter.router);
-  app.use(ProductionRouter.router);
-  app.use(TierlistRouter.router);
   HealthRouter.register(new HealthController());
   MealRouter.register(new MealController());
   RankingRouter.register(new RankingController());

--- a/backend/src/assets/functions.js
+++ b/backend/src/assets/functions.js
@@ -32,17 +32,19 @@ function getQueryParams() {
 
 function makeRequest(url, method, callback, body) {
   var xmlhttp = new XMLHttpRequest();
+  var apiUrl = 'api/' + url;
+
+  // add loading indicator while waiting for response
   xmlhttp.onreadystatechange = function () {
     if (this.readyState == 1) {
       document.getElementById('spinner-div').style.display = 'block';
-    }
-    // Hide spinner when the request is done
-    else if (this.readyState == 4) {
+    } else if (this.readyState == 4) {
       document.getElementById('spinner-div').style.display = 'none';
       callback(this.responseText);
     }
   };
-  xmlhttp.open(method, url, true);
+
+  xmlhttp.open(method, apiUrl, true);
   xmlhttp.setRequestHeader('Content-Type', 'application/json');
   xmlhttp.send(JSON.stringify(body));
 }

--- a/backend/src/controllers/calculator/production.controller.ts
+++ b/backend/src/controllers/calculator/production.controller.ts
@@ -1,10 +1,11 @@
-import { Body, Controller, Path, Post, Route } from 'tsoa';
+import { Body, Controller, Path, Post, Route, Tags } from 'tsoa';
 import { ProductionRequest } from '../../routes/calculator-router/production-router';
 import { calculatePokemonProduction } from '../../services/routing-service/production/production-service';
 
-@Route('calculator')
+@Route('api/calculator')
+@Tags('calculator')
 export default class ProductionController extends Controller {
-  @Post('/production/{name}')
+  @Post('production/{name}')
   public async calculatePokemonProduction(@Path() name: string, @Body() body: ProductionRequest) {
     return calculatePokemonProduction(name, body);
   }

--- a/backend/src/controllers/health/health.controller.ts
+++ b/backend/src/controllers/health/health.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, Hidden, Route } from 'tsoa';
+import { Controller, Get, Hidden, Route, Tags } from 'tsoa';
 import { DatabaseService } from '../../database/database-service';
 import { Logger } from '../../services/logger/logger';
 
 @Route('health')
+@Tags('system')
 export default class HealthController extends Controller {
   @Get('/')
   @Hidden()

--- a/backend/src/controllers/meal/meal.controller.ts
+++ b/backend/src/controllers/meal/meal.controller.ts
@@ -1,12 +1,13 @@
-import { Controller, Get, Path, Queries, Route } from 'tsoa';
+import { Controller, Get, Path, Queries, Route, Tags } from 'tsoa';
 import { MealNamesQueryParams, MealRankingQueryParams } from '../../routes/meal-router/meal-router';
 import { getMealDataAndRankingFor, getMealNamesForFilter } from '../../services/routing-service/meal-ranking';
 import { findIslandForName } from '../../utils/island-utils/island-utils';
 import { queryAsBoolean } from '../../utils/routing/routing-utils';
 
-@Route('meal')
+@Route('api/meal')
 export default class MealController extends Controller {
   @Get('/')
+  @Tags('meal')
   public async getMeals(@Queries() queryParams: MealNamesQueryParams): Promise<string[]> {
     const params = {
       advanced: queryAsBoolean(queryParams.advanced),
@@ -19,7 +20,9 @@ export default class MealController extends Controller {
     return getMealNamesForFilter(params);
   }
 
+  // TODO: move to legacy
   @Get('{name}')
+  @Tags('legacy')
   public async getMealRankingRaw(@Path() name: string, @Queries() queryParams: MealRankingQueryParams) {
     const params = {
       name: name,

--- a/backend/src/controllers/optimal/optimal.controller.ts
+++ b/backend/src/controllers/optimal/optimal.controller.ts
@@ -1,16 +1,18 @@
-import { Controller, Get, Path, Queries, Route } from 'tsoa';
+import { Controller, Get, Path, Queries, Route, Tags } from 'tsoa';
 import { FilteredQueryParams } from '../../routes/optimal-router/optimal-router';
 import { getOptimalPokemonFor } from '../../services/routing-service/optimal-ranking';
 import { findIslandForName } from '../../utils/island-utils/island-utils';
-import { queryAsBoolean, queryAsMandatoryNumber, queryAsNumber } from '../../utils/routing/routing-utils';
+import { queryAsBoolean, queryAsNumber } from '../../utils/routing/routing-utils';
 
-@Route('optimal')
+// TODO: rename to team finder
+@Route('api/optimal')
+@Tags('optimal')
 export default class OptimalController extends Controller {
   @Get('{name}')
   public getOptimalPokemonForMealRaw(@Path() name: string, @Queries() queryParams: FilteredQueryParams) {
     const params = {
       name,
-      level: queryAsMandatoryNumber('level', queryParams.level),
+      level: queryAsNumber(queryParams.level),
       e4eProcs: queryAsNumber(queryParams.e4e),
       helpingBonus: queryAsNumber(queryParams.helpingbonus),
       goodCamp: queryAsBoolean(queryParams.camp),

--- a/backend/src/controllers/pokemon/pokemon.controller.ts
+++ b/backend/src/controllers/pokemon/pokemon.controller.ts
@@ -1,12 +1,13 @@
-import { Controller, Get, Path, Queries, Route } from 'tsoa';
+import { Controller, Get, Path, Queries, Route, Tags } from 'tsoa';
 import { GetPokemonQueryParams, MealsForPokemonRequestQueryParams } from '../../routes/pokemon-router/pokemon-router';
 import { getPokemonCombinationData } from '../../services/routing-service/pokemon-ranking';
 import { getPokemonNames } from '../../utils/pokemon-utils/pokemon-utils';
 import { queryAsBoolean } from '../../utils/routing/routing-utils';
 
-@Route('pokemon')
+@Route('api/pokemon')
 export default class PokemonController extends Controller {
   @Get('/')
+  @Tags('pokemon')
   public async getPokemon(@Queries() queryParams: GetPokemonQueryParams): Promise<string[]> {
     const params = {
       cyan: queryAsBoolean(queryParams.cyan),
@@ -17,7 +18,9 @@ export default class PokemonController extends Controller {
     return getPokemonNames(params);
   }
 
+  // TODO: move to legacy
   @Get('{name}')
+  @Tags('legacy')
   public async getPokemonRankingRaw(@Path() name: string, @Queries() queryParams: MealsForPokemonRequestQueryParams) {
     const params = {
       name: name,

--- a/backend/src/controllers/ranking/ranking.controller.ts
+++ b/backend/src/controllers/ranking/ranking.controller.ts
@@ -1,12 +1,13 @@
-import { Controller, Get, Hidden, Path, Queries, Route } from 'tsoa';
+import { Controller, Get, Hidden, Path, Queries, Route, Tags } from 'tsoa';
 import { FilteredExtQueryParams, FilteredMealsQueryParams } from '../../routes/ranking-router/ranking-router';
 import { getBuddyFlexibleRanking, getBuddyRankingFor } from '../../services/routing-service/buddy-ranking';
 import { getMealFocusedRanking, getMealGeneralistRanking } from '../../services/routing-service/meal-ranking';
 import { queryAsBoolean, queryAsNumber } from '../../utils/routing/routing-utils';
 
-@Route('ranking')
+@Route('api/ranking')
+@Tags('legacy')
 export default class RankingController extends Controller {
-  @Get('/meal/flexible')
+  @Get('meal/flexible')
   public async getMealGeneralistRankingRaw(@Queries() queryParams: FilteredMealsQueryParams) {
     const params = {
       limit30: queryAsBoolean(queryParams.limit30),
@@ -24,7 +25,7 @@ export default class RankingController extends Controller {
     return getMealGeneralistRanking(params);
   }
 
-  @Get('/meal/focused')
+  @Get('meal/focused')
   public async getMealFocusedRankingRaw(@Queries() queryParams: FilteredExtQueryParams) {
     const params = {
       limit30: queryAsBoolean(queryParams.limit30),
@@ -43,7 +44,7 @@ export default class RankingController extends Controller {
     return getMealFocusedRanking(params);
   }
 
-  @Get('/buddy/flexible')
+  @Get('buddy/flexible')
   @Hidden()
   public async getBuddyFlexibleRankingRaw(@Queries() queryParams: FilteredExtQueryParams) {
     const params = {
@@ -63,7 +64,7 @@ export default class RankingController extends Controller {
     return getBuddyFlexibleRanking(params);
   }
 
-  @Get('/buddy/meal/{name}')
+  @Get('buddy/meal/{name}')
   @Hidden()
   public async getBuddyMealRankingRaw(@Path() name: string, @Queries() queryParams: FilteredExtQueryParams) {
     const params = {

--- a/backend/src/controllers/tierlist/tierlist.controller.ts
+++ b/backend/src/controllers/tierlist/tierlist.controller.ts
@@ -1,8 +1,9 @@
-import { Body, Controller, Get, Hidden, Post, Queries, Route } from 'tsoa';
+import { Body, Controller, Get, Hidden, Post, Queries, Route, Tags } from 'tsoa';
 import { CreateTierListRequestBody, GetTierListQueryParams } from '../../routes/tierlist-router/tierlist-router';
 import { CookingTierlistService } from '../../services/routing-service/tierlist/cooking-tierlist-service';
 
-@Route('tierlist')
+@Route('api/tierlist')
+@Tags('tierlist')
 export default class TierlistController extends Controller {
   @Post('cooking')
   @Hidden()

--- a/backend/src/public/swagger.json
+++ b/backend/src/public/swagger.json
@@ -1085,7 +1085,7 @@
 	},
 	"openapi": "3.0.0",
 	"paths": {
-		"/optimal/{name}": {
+		"/api/optimal/{name}": {
 			"get": {
 				"operationId": "GetOptimalPokemonForMealRaw",
 				"responses": {
@@ -1207,6 +1207,9 @@
 						}
 					}
 				},
+				"tags": [
+					"optimal"
+				],
 				"security": [],
 				"parameters": [
 					{
@@ -1295,7 +1298,7 @@
 				]
 			}
 		},
-		"/pokemon": {
+		"/api/pokemon": {
 			"get": {
 				"operationId": "GetPokemon",
 				"responses": {
@@ -1313,6 +1316,9 @@
 						}
 					}
 				},
+				"tags": [
+					"pokemon"
+				],
 				"security": [],
 				"parameters": [
 					{
@@ -1358,7 +1364,7 @@
 				]
 			}
 		},
-		"/pokemon/{name}": {
+		"/api/pokemon/{name}": {
 			"get": {
 				"operationId": "GetPokemonRankingRaw",
 				"responses": {
@@ -1374,6 +1380,9 @@
 						}
 					}
 				},
+				"tags": [
+					"legacy"
+				],
 				"security": [],
 				"parameters": [
 					{
@@ -1459,7 +1468,7 @@
 				]
 			}
 		},
-		"/tierlist/cooking": {
+		"/api/tierlist/cooking": {
 			"get": {
 				"operationId": "GetCookingTierlist",
 				"responses": {
@@ -1477,6 +1486,9 @@
 						}
 					}
 				},
+				"tags": [
+					"tierlist"
+				],
 				"security": [],
 				"parameters": [
 					{
@@ -1522,7 +1534,7 @@
 				]
 			}
 		},
-		"/calculator/production/{name}": {
+		"/api/calculator/production/{name}": {
 			"post": {
 				"operationId": "CalculatePokemonProduction",
 				"responses": {
@@ -1586,6 +1598,9 @@
 						}
 					}
 				},
+				"tags": [
+					"calculator"
+				],
 				"security": [],
 				"parameters": [
 					{
@@ -1609,7 +1624,7 @@
 				}
 			}
 		},
-		"/meal": {
+		"/api/meal": {
 			"get": {
 				"operationId": "GetMeals",
 				"responses": {
@@ -1627,6 +1642,9 @@
 						}
 					}
 				},
+				"tags": [
+					"meal"
+				],
 				"security": [],
 				"parameters": [
 					{
@@ -1688,7 +1706,7 @@
 				]
 			}
 		},
-		"/meal/{name}": {
+		"/api/meal/{name}": {
 			"get": {
 				"operationId": "GetMealRankingRaw",
 				"responses": {
@@ -1703,6 +1721,9 @@
 						}
 					}
 				},
+				"tags": [
+					"legacy"
+				],
 				"security": [],
 				"parameters": [
 					{
@@ -1748,7 +1769,7 @@
 				]
 			}
 		},
-		"/ranking/meal/flexible": {
+		"/api/ranking/meal/flexible": {
 			"get": {
 				"operationId": "GetMealGeneralistRankingRaw",
 				"responses": {
@@ -1766,6 +1787,9 @@
 						}
 					}
 				},
+				"tags": [
+					"legacy"
+				],
 				"security": [],
 				"parameters": [
 					{
@@ -1875,7 +1899,7 @@
 				]
 			}
 		},
-		"/ranking/meal/focused": {
+		"/api/ranking/meal/focused": {
 			"get": {
 				"operationId": "GetMealFocusedRankingRaw",
 				"responses": {
@@ -1893,6 +1917,9 @@
 						}
 					}
 				},
+				"tags": [
+					"legacy"
+				],
 				"security": [],
 				"parameters": [
 					{

--- a/backend/src/routes/base-router.ts
+++ b/backend/src/routes/base-router.ts
@@ -1,0 +1,7 @@
+import express from 'express';
+
+class BaseRouterImpl {
+  public router = express.Router();
+}
+
+export const BaseRouter = new BaseRouterImpl();

--- a/backend/src/routes/calculator-router/production-router.ts
+++ b/backend/src/routes/calculator-router/production-router.ts
@@ -1,8 +1,9 @@
-import express, { Request, Response } from 'express';
+import { Request, Response } from 'express';
 import ProductionController from '../../controllers/calculator/production.controller';
 import { Logger } from '../../services/logger/logger';
 import { WebsiteConverterService } from '../../services/website-converter/website-converter-service';
 import { queryAsBoolean, queryAsNumber } from '../../utils/routing/routing-utils';
+import { BaseRouter } from '../base-router';
 
 export interface ProductionRequest {
   level: number;
@@ -14,10 +15,8 @@ export interface ProductionRequest {
 }
 
 class ProductionRouterImpl {
-  public router = express.Router();
-
   public async register(controller: ProductionController) {
-    this.router.post(
+    BaseRouter.router.post(
       '/calculator/production/:name',
       async (req: Request<{ name: string }, unknown, ProductionRequest, { pretty?: boolean }>, res: Response) => {
         try {

--- a/backend/src/routes/health-router/health-router.ts
+++ b/backend/src/routes/health-router/health-router.ts
@@ -1,12 +1,10 @@
-import express from 'express';
 import HealthController from '../../controllers/health/health.controller';
 import { Logger } from '../../services/logger/logger';
+import { BaseRouter } from '../base-router';
 
 class HealthRouterImpl {
-  public router = express.Router();
-
   public async register(controller: HealthController) {
-    this.router.get('/health', async (req, res) => {
+    BaseRouter.router.get('/health', async (req, res) => {
       try {
         Logger.log('Entered /health');
         const health = await controller.health();

--- a/backend/src/routes/meal-router/meal-router.ts
+++ b/backend/src/routes/meal-router/meal-router.ts
@@ -1,9 +1,10 @@
-import express, { Request, Response } from 'express';
+import { Request, Response } from 'express';
 import MealController from '../../controllers/meal/meal.controller';
 import { CSVConverterService } from '../../services/csv-converter/csv-converter-service';
 import { Logger } from '../../services/logger/logger';
 import { WebsiteConverterService } from '../../services/website-converter/website-converter-service';
 import { queryAsBoolean, respondWithCSV } from '../../utils/routing/routing-utils';
+import { BaseRouter } from '../base-router';
 
 export interface MealNamesQueryParams {
   advanced?: boolean;
@@ -23,27 +24,28 @@ export interface MealRankingQueryParams {
 }
 
 class MealRouterImpl {
-  public router = express.Router();
-
   public async register(controller: MealController) {
-    this.router.get('/meal', async (req: Request<unknown, unknown, unknown, MealNamesQueryParams>, res: Response) => {
-      try {
-        Logger.log('Entered /meal');
-        const meals = await controller.getMeals(req.query);
+    BaseRouter.router.get(
+      '/meal',
+      async (req: Request<unknown, unknown, unknown, MealNamesQueryParams>, res: Response) => {
+        try {
+          Logger.log('Entered /meal');
+          const meals = await controller.getMeals(req.query);
 
-        if (queryAsBoolean(req.query.csv) === true) {
-          const data = 'Name\n' + `${meals.join('\n')}`;
-          respondWithCSV(res, data, 'meals');
-        } else {
-          res.header('Content-Type', 'application/json').send(JSON.stringify(meals, null, 4));
+          if (queryAsBoolean(req.query.csv) === true) {
+            const data = 'Name\n' + `${meals.join('\n')}`;
+            respondWithCSV(res, data, 'meals');
+          } else {
+            res.header('Content-Type', 'application/json').send(JSON.stringify(meals, null, 4));
+          }
+        } catch (err) {
+          Logger.error(err as Error);
+          res.status(500).send('Something went wrong');
         }
-      } catch (err) {
-        Logger.error(err as Error);
-        res.status(500).send('Something went wrong');
       }
-    });
+    );
 
-    this.router.get(
+    BaseRouter.router.get(
       '/meal/:name',
       async (req: Request<{ name: string }, unknown, unknown, MealRankingQueryParams>, res: Response) => {
         try {

--- a/backend/src/routes/optimal-router/optimal-router.ts
+++ b/backend/src/routes/optimal-router/optimal-router.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express';
+import { Request, Response } from 'express';
 import { config } from '../../config/config';
 import OptimalController from '../../controllers/optimal/optimal.controller';
 import { CustomPokemonCombinationWithProduce } from '../../domain/combination/custom';
@@ -9,6 +9,7 @@ import { CSVConverterService } from '../../services/csv-converter/csv-converter-
 import { Logger } from '../../services/logger/logger';
 import { WebsiteConverterService } from '../../services/website-converter/website-converter-service';
 import { queryAsBoolean, queryParamsToString, respondWithCSV } from '../../utils/routing/routing-utils';
+import { BaseRouter } from '../base-router';
 
 export interface FilteredQueryParams {
   level?: number;
@@ -43,10 +44,8 @@ export interface OptimalSetResult {
 }
 
 class OptimalCombinationRouterImpl {
-  public router = express.Router();
-
   public async register(controller: OptimalController) {
-    this.router.get(
+    BaseRouter.router.get(
       '/optimal/:name',
       async (req: Request<{ name: string }, unknown, unknown, FilteredQueryParams>, res: Response) => {
         try {

--- a/backend/src/routes/pokemon-router/pokemon-router.ts
+++ b/backend/src/routes/pokemon-router/pokemon-router.ts
@@ -1,10 +1,11 @@
-import express, { Request, Response } from 'express';
+import { Request, Response } from 'express';
 import PokemonController from '../../controllers/pokemon/pokemon.controller';
 import { IngredientDrop } from '../../domain/produce/ingredient';
 import { CSVConverterService } from '../../services/csv-converter/csv-converter-service';
 import { Logger } from '../../services/logger/logger';
 import { WebsiteConverterService } from '../../services/website-converter/website-converter-service';
 import { queryAsBoolean, respondWithCSV } from '../../utils/routing/routing-utils';
+import { BaseRouter } from '../base-router';
 
 export interface GetPokemonQueryParams {
   cyan?: boolean;
@@ -39,10 +40,8 @@ export interface PokemonResult {
 }
 
 class PokemonRouterImpl {
-  public router = express.Router();
-
   public async register(controller: PokemonController) {
-    this.router.get(
+    BaseRouter.router.get(
       '/pokemon',
       async (req: Request<unknown, unknown, unknown, GetPokemonQueryParams>, res: Response) => {
         try {
@@ -62,7 +61,7 @@ class PokemonRouterImpl {
       }
     );
 
-    this.router.get(
+    BaseRouter.router.get(
       '/pokemon/:name',
       async (req: Request<{ name: string }, unknown, unknown, MealsForPokemonRequestQueryParams>, res: Response) => {
         try {

--- a/backend/src/routes/ranking-router/ranking-router.ts
+++ b/backend/src/routes/ranking-router/ranking-router.ts
@@ -1,9 +1,10 @@
-import express, { Request, Response } from 'express';
+import { Request, Response } from 'express';
 import RankingController from '../../controllers/ranking/ranking.controller';
 import { CSVConverterService } from '../../services/csv-converter/csv-converter-service';
 import { Logger } from '../../services/logger/logger';
 import { WebsiteConverterService } from '../../services/website-converter/website-converter-service';
 import { queryAsBoolean, queryParamsToString, respondWithCSV } from '../../utils/routing/routing-utils';
+import { BaseRouter } from '../base-router';
 
 export interface FilteredMealsQueryParams {
   limit30?: boolean;
@@ -27,10 +28,8 @@ export interface FilteredExtQueryParams extends FilteredMealsQueryParams {
 }
 
 class RankingRouterImpl {
-  public router = express.Router();
-
   public async register(controller: RankingController) {
-    this.router.get(
+    BaseRouter.router.get(
       '/ranking/meal/flexible',
       async (req: Request<{ name: string }, unknown, unknown, FilteredMealsQueryParams>, res: Response) => {
         try {
@@ -55,7 +54,7 @@ class RankingRouterImpl {
       }
     );
 
-    this.router.get(
+    BaseRouter.router.get(
       '/ranking/meal/focused',
       async (req: Request<{ name: string }, unknown, unknown, FilteredExtQueryParams>, res: Response) => {
         try {
@@ -80,7 +79,7 @@ class RankingRouterImpl {
       }
     );
 
-    this.router.get(
+    BaseRouter.router.get(
       '/ranking/buddy/flexible',
       async (req: Request<{ name: string }, unknown, unknown, FilteredExtQueryParams>, res: Response) => {
         try {
@@ -105,7 +104,7 @@ class RankingRouterImpl {
       }
     );
 
-    this.router.get(
+    BaseRouter.router.get(
       '/ranking/buddy/meal/:name',
       async (req: Request<{ name: string }, unknown, unknown, FilteredExtQueryParams>, res: Response) => {
         try {

--- a/backend/src/routes/tierlist-router/tierlist-router.ts
+++ b/backend/src/routes/tierlist-router/tierlist-router.ts
@@ -1,10 +1,11 @@
-import express, { Request, Response } from 'express';
+import { Request, Response } from 'express';
 import { config } from '../../config/config';
 import TierlistController from '../../controllers/tierlist/tierlist.controller';
 import { PokemonCombinationContribution } from '../../domain/combination/combination-contribution';
 import { Logger } from '../../services/logger/logger';
 import { WebsiteConverterService } from '../../services/website-converter/website-converter-service';
 import { queryAsBoolean } from '../../utils/routing/routing-utils';
+import { BaseRouter } from '../base-router';
 
 export type TierlistType = 'overall' | 'curry' | 'salad' | 'dessert';
 export interface GetTierListQueryParams {
@@ -34,10 +35,8 @@ export interface TieredPokemonCombinationContribution {
 }
 
 class TierlistRouterImpl {
-  public router = express.Router();
-
   public async register(controller: TierlistController) {
-    this.router.post(
+    BaseRouter.router.post(
       '/tierlist/cooking/create',
       async (
         req: Request<unknown, unknown, CreateTierListRequestBody, { pretty: boolean; onlyBest: boolean }>,
@@ -66,7 +65,7 @@ class TierlistRouterImpl {
       }
     );
 
-    this.router.get(
+    BaseRouter.router.get(
       '/tierlist/cooking',
       async (req: Request<unknown, unknown, unknown, GetTierListQueryParams>, res: Response) => {
         try {

--- a/backend/src/services/routing-service/optimal-ranking.ts
+++ b/backend/src/services/routing-service/optimal-ranking.ts
@@ -9,7 +9,7 @@ import { subskillsForFilter } from '../calculator/stats/stats-calculator';
 
 export function getOptimalPokemonFor(params: {
   name: string;
-  level: number;
+  level?: number;
   island?: Island;
   goodCamp: boolean;
   e4eProcs?: number;
@@ -20,7 +20,7 @@ export function getOptimalPokemonFor(params: {
   const {
     name,
     island,
-    level,
+    level = 60,
     goodCamp,
     e4eProcs = 0,
     helpingBonus = 0,

--- a/backend/src/utils/routing/routing-utils.test.ts
+++ b/backend/src/utils/routing/routing-utils.test.ts
@@ -1,4 +1,4 @@
-import { queryAsBoolean, queryAsMandatoryNumber, queryAsNumber, queryParamsToString } from './routing-utils';
+import { queryAsBoolean, queryAsNumber, queryParamsToString } from './routing-utils';
 
 describe('queryAsBoolean', () => {
   it('shall convert true to true', () => {
@@ -33,20 +33,6 @@ describe('queryAsNumber', () => {
 
   it('shall convert undefined to undefined', () => {
     expect(queryAsNumber(undefined)).toBe(undefined);
-  });
-});
-
-describe('queryAsMandatoryNumber', () => {
-  it('shall convert 3 to 3', () => {
-    expect(queryAsMandatoryNumber('testKey', 3)).toBe(3);
-  });
-
-  it('shall convert "3" string to 3', () => {
-    expect(queryAsMandatoryNumber('testKey', '3')).toBe(3);
-  });
-
-  it('shall throw error for undefined', () => {
-    expect(() => queryAsMandatoryNumber('testKey', undefined)).toThrow('Missing query parameter value for [testKey]');
   });
 });
 

--- a/backend/src/utils/routing/routing-utils.ts
+++ b/backend/src/utils/routing/routing-utils.ts
@@ -16,13 +16,6 @@ export function queryAsNumber(value: string | number | undefined): number | unde
   return value ? +value : undefined;
 }
 
-export function queryAsMandatoryNumber(key: string, value: string | number | undefined): number {
-  if (!value) {
-    throw new Error(`Missing query parameter value for [${key}]`);
-  }
-  return +value;
-}
-
 export function queryParamsToString(params: QueryToCSVFileName): string {
   let result = '';
   const { level, advanced, unlocked, lategame, nrOfMeals } = params;


### PR DESCRIPTION
**WHY**

We need to support routing all API-related queries to a different address. To do this we should group the calls from frontend under /api path.

**WHAT**

Changed root of API to /api from /. Updated swagger documentation adding swagger documentation tags for groupings.

Closes #76 