### PR TITLE
fix: use vuetify tree shaking instead of load all components

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,8 +4,6 @@ import { createApp } from 'vue'
 // Vuetify
 import '@mdi/font/css/materialdesignicons.css'
 import { createVuetify } from 'vuetify'
-import * as components from 'vuetify/components'
-import * as directives from 'vuetify/directives'
 import 'vuetify/styles'
 
 import '@/assets/main.scss'
@@ -36,9 +34,7 @@ const vuetify = createVuetify({
     themes: {
       darkTheme
     }
-  },
-  components,
-  directives
+  }
 })
 
 app.use(createPinia())

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -1,10 +1,11 @@
 import vue from '@vitejs/plugin-vue'
+import vuetify from 'vite-plugin-vuetify'
 import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), vuetify()],
   server: {
     port: 8001,
     proxy: {

--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -8,11 +8,11 @@ export default mergeConfig(
   defineConfig({
     test: {
       environment: 'jsdom',
-      exclude: [...configDefaults.exclude, 'e2e/*'],
+      exclude: [...configDefaults.exclude, 'e2e/*', '**/main.ts'],
       root: fileURLToPath(new URL('./', import.meta.url)),
       coverage: {
         include: ['**/src/**'],
-        exclude: ['**/node_modules/**', '**/test/**']
+        exclude: ['**/node_modules/**', '**/test/**', '**/main.ts']
       },
       setupFiles: ['./src/vitest']
     }


### PR DESCRIPTION
https://vuetifyjs.com/en/features/treeshaking/
Instead of loading all components on site load, we can trim down what and when to load components. This will hopefully decrease bytes transferred and loading time