### PR TITLE
Add per-ingredient ranking to API

### DIFF
--- a/backend/src/controllers/optimal/optimal.controller.ts
+++ b/backend/src/controllers/optimal/optimal.controller.ts
@@ -7,7 +7,11 @@ import { parseTime } from '@src/utils/time-utils/time-utils';
 import { mainskill } from 'sleepapi-common';
 import { Body, Controller, Path, Post, Route, Tags } from 'tsoa';
 import { InputProductionStatsRequest } from '../../routes/optimal-router/optimal-router';
-import { findOptimalSetsForMeal, getOptimalFlexiblePokemon } from '../../services/api-service/optimal/optimal-service';
+import {
+  findOptimalMonsForIngredient,
+  findOptimalSetsForMeal,
+  getOptimalFlexiblePokemon,
+} from '../../services/api-service/optimal/optimal-service';
 
 @Route('api/optimal')
 @Tags('optimal')
@@ -20,6 +24,11 @@ export default class OptimalController extends Controller {
   @Post('meal/{name}')
   public getOptimalPokemonForMealRaw(@Path() name: string, @Body() input: InputProductionStatsRequest) {
     return findOptimalSetsForMeal(name, this.#parseInputProductionStatsRequest(input), 500);
+  }
+
+  @Post('ingredient/{name}')
+  public getOptimalPokemonForIngredientRaw(@Path() name: string, @Body() input: InputProductionStatsRequest) {
+    return findOptimalMonsForIngredient(name, this.#parseInputProductionStatsRequest(input), 500);
   }
 
   #parseInputProductionStatsRequest(input: InputProductionStatsRequest): SetCoverProductionStats {

--- a/backend/src/public/swagger.json
+++ b/backend/src/public/swagger.json
@@ -1400,6 +1400,66 @@
 				}
 			}
 		},
+		"/api/optimal/ingredient/{name}": {
+			"post": {
+				"operationId": "GetOptimalPokemonForIngredientRaw",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"teams": {
+											"items": {
+												"$ref": "#/components/schemas/OptimalTeamSolution"
+											},
+											"type": "array"
+										},
+										"filter": {
+											"$ref": "#/components/schemas/SetCoverProductionStats"
+										},
+										"ingredient": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"teams",
+										"filter",
+										"ingredient"
+									],
+									"type": "object"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"optimal"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "name",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/InputProductionStatsRequest"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/api/tierlist/cooking": {
 			"get": {
 				"operationId": "GetCookingTierlist",

--- a/backend/src/routes/optimal-router/optimal-router.ts
+++ b/backend/src/routes/optimal-router/optimal-router.ts
@@ -49,8 +49,40 @@ export interface OptimalSetResult {
   teams: OptimalTeamSolution[];
 }
 
+export interface IngredientRankerResult {
+  ingredient: string;
+  filter: ProductionStats;
+  teams: OptimalTeamSolution[];
+}
+
 class OptimalCombinationRouterImpl {
   public async register(controller: OptimalController) {
+    BaseRouter.router.post(
+      '/optimal/ingredient/:name',
+      async (
+        req: Request<{ name: string }, unknown, InputProductionStatsRequest, { pretty?: boolean }>,
+        res: Response
+      ) => {
+        try {
+          Logger.log('Entered /optimal/ingredient/:name');
+          const { pretty } = req.query;
+          const mealName = req.params.name;
+
+          const data: IngredientRankerResult = controller.getOptimalPokemonForIngredientRaw(mealName, req.body);
+
+          if (queryAsBoolean(pretty)) {
+            const optimalData = WebsiteConverterService.toIngredientRanker(data);
+            res.header('Content-Type', 'application/json').send(JSON.stringify(optimalData, null, 4));
+          } else {
+            res.header('Content-Type', 'application/json').send(JSON.stringify(data, null, 4));
+          }
+        } catch (err) {
+          Logger.error(err as Error);
+          res.status(500).send('Something went wrong');
+        }
+      }
+    );
+
     BaseRouter.router.post(
       '/optimal/meal/flexible',
       async (req: Request<unknown, unknown, InputProductionStatsRequest, { pretty: boolean }>, res: Response) => {

--- a/backend/src/services/api-service/optimal/optimal-service.test.ts
+++ b/backend/src/services/api-service/optimal/optimal-service.test.ts
@@ -1,7 +1,7 @@
 import { SetCoverProductionStats } from '@src/domain/computed/production';
-import { berry, dessert, nature, subskill } from 'sleepapi-common';
+import { berry, dessert, ingredient, nature, subskill } from 'sleepapi-common';
 import { prettifyIngredientDrop } from '../../../utils/json/json-utils';
-import { findOptimalSetsForMeal, getOptimalFlexiblePokemon } from './optimal-service';
+import { findOptimalMonsForIngredient, findOptimalSetsForMeal, getOptimalFlexiblePokemon } from './optimal-service';
 
 describe('findOptimalSetsForMeal', () => {
   it('shall find all optimal solutions for a recipe', () => {
@@ -50,6 +50,38 @@ describe('findOptimalSetsForMeal', () => {
         },
       ]
     `);
+  });
+});
+
+describe('findOptimalMonsForIngredient', () => {
+  it('shall find all optimal mons for an ingredient', () => {
+    const input: SetCoverProductionStats = {
+      level: 30,
+      nature: nature.RASH,
+      subskills: [],
+      berries: berry.BERRIES,
+      e4eProcs: 0,
+      e4eLevel: 6,
+      cheer: 0,
+      extraHelpful: 0,
+      helperBoostProcs: 0,
+      helperBoostUnique: 1,
+      helperBoostLevel: 6,
+      helpingBonus: 0,
+      camp: false,
+      erb: 0,
+      incense: false,
+      skillLevel: 6,
+      mainBedtime: { hour: 21, minute: 30, second: 0 },
+      mainWakeup: { hour: 6, minute: 0, second: 0 },
+    };
+    const teams = findOptimalMonsForIngredient(ingredient.SLOWPOKE_TAIL.name, input, 1).teams.filter(
+      (team) => team.surplus.relevant[0].amount >= 0.999
+    );
+    expect(teams).toHaveLength(2);
+    const pokemonNames = teams.map((team) => team.team.map((member) => member.pokemonCombination.pokemon.name));
+    expect(pokemonNames).toContainEqual(['SLOWBRO']);
+    expect(pokemonNames).toContainEqual(['SLOWKING']);
   });
 });
 

--- a/backend/src/services/api-service/optimal/optimal-service.ts
+++ b/backend/src/services/api-service/optimal/optimal-service.ts
@@ -8,6 +8,7 @@ import {
   calculateOptimalProductionForSetCover,
   calculateSetCover,
 } from '@src/services/calculator/set-cover/calculate-set-cover';
+import { getIngredientForName } from '@src/utils/ingredient-utils/ingredient-utils';
 import { calculateCritMultiplier, CritInfo, getMeal, getMealsForFilter } from '@src/utils/meal-utils/meal-utils';
 import {
   calculateCombinedContributions,
@@ -26,6 +27,36 @@ const FLEXIBLE_SET_COVER_TIMEOUT = 3000;
  */
 export function findOptimalSetsForMeal(mealName: string, input: SetCoverProductionStats, monteCarloIterations: number) {
   return customOptimalSet(mealName, input, TEAMFINDER_SET_COVER_TIMEOUT, monteCarloIterations);
+}
+
+/**
+ * Finds the optimal Pokemon for a specific ingredient
+ *
+ * API: /api/optimal/ingredient
+ */
+export function findOptimalMonsForIngredient(
+  ingredientName: string,
+  input: SetCoverProductionStats,
+  monteCarloIterations: number
+) {
+  const ingredient = getIngredientForName(ingredientName);
+  const ingAsRecipe = [{ ingredient: ingredient, amount: 0.001 }];
+  const pokemonProduction = calculateOptimalProductionForSetCover(input, monteCarloIterations);
+  const reverseIndex = createPokemonByIngredientReverseIndex(pokemonProduction);
+
+  const optimalCombinations = calculateSetCover({
+    recipe: ingAsRecipe,
+    cache: new Map(),
+    reverseIndex,
+    maxTeamSize: 1,
+    timeout: TEAMFINDER_SET_COVER_TIMEOUT,
+  });
+
+  return {
+    ingredient: ingredient.name,
+    filter: input,
+    teams: optimalCombinations,
+  };
 }
 
 /**


### PR DESCRIPTION
Compute a ranking for individual ingredients. I barely looked at how I want the data to output, so that'll need some attention eventually, but probably not a big deal until it's added to a frontend, either current or new.

Note that this approach doesn't report any mon that finds an ingredient rarely enough to be less than 1 per meal window. So Jolly level 30 Slowking might be excluded, as it finds 0.9 Tails per meal window. Not sure if there are any other settings where Pokemon can be excluded. (Slowpoke also gets <1 Tail, but it's already excluded because it's not fully-evolved.)