### PR TITLE
WIP: add events to production calculator

### DIFF
--- a/backend/src/domain/computed/production.ts
+++ b/backend/src/domain/computed/production.ts
@@ -1,4 +1,4 @@
-import { berry, nature, Recipe, subskill } from 'sleepapi-common';
+import { Event, Recipe, berry, nature, subskill } from 'sleepapi-common';
 import { CustomPokemonCombinationWithProduce } from '../combination/custom';
 import { Time } from '../time/time';
 
@@ -22,6 +22,7 @@ export interface ProductionStats {
   mainBedtime: Time;
   mainWakeup: Time;
   maxPotSize?: number;
+  event?: Event;
 }
 
 export interface SetCoverProductionStats extends ProductionStats {

--- a/common/src/domain/event/event.ts
+++ b/common/src/domain/event/event.ts
@@ -1,0 +1,92 @@
+import { AddOneIngredient } from '../../utils';
+import { GREPA, LEPPA } from '../berry';
+import { Pokemon } from '../pokemon';
+
+export interface Event {
+  name: string;
+  description: string;
+  startDate: Date;
+  endDate: Date;
+  statModifier: (mon: Pokemon) => Pokemon;
+}
+
+export const FIRST_ANNIVERSARY_FEST: Event = {
+  name: 'First Anniversary Fest',
+  description: "The chance of each helper Pokemon's main skill triggering will be multiplied by 1.5.",
+  startDate: new Date(2024, 7, 15),
+  endDate: new Date(2024, 7, 21),
+  statModifier: (mon: Pokemon) => {
+    return {
+      skillPercentage: mon.skillPercentage * 1.5,
+      ...mon,
+    };
+  },
+};
+
+export const ENTEI_RESEARCH: Event = {
+  name: 'Entei Research',
+  description:
+    'Fire-type Pokemon find an extra ingredient every time they find ingredients, and their main ' +
+    'skill triggers 50% more often. During the first week, fire-type Pokemon have their main ' +
+    'skill level increased by 1; during the second week, it increases by 3.',
+  startDate: new Date(2024, 5, 20),
+  endDate: new Date(2024, 6, 3),
+  statModifier: (mon: Pokemon) => {
+    if (mon.berry != LEPPA) {
+      return mon;
+    }
+    return {
+      ingredient0: AddOneIngredient(mon.ingredient0),
+      ingredient30: mon.ingredient30.map(AddOneIngredient),
+      ingredient60: mon.ingredient60.map(AddOneIngredient),
+      skillPercentage: mon.skillPercentage * 1.5,
+      ...mon,
+      // For week 1, Main Skill Level is increased by 1
+      // For week 2, Main Skill Level is increased by 3
+    };
+  },
+};
+
+export const RAIKOU_RESEARCH: Event = {
+  name: 'Raikou Research',
+  description:
+    'Electric-type Pokemon find an extra ingredient every time they find ingredients, and their ' +
+    'main skill triggers 50% more often.',
+  startDate: new Date(2024, 3, 25),
+  endDate: new Date(2024, 4, 7),
+  statModifier: (mon: Pokemon) => {
+    if (mon.berry != GREPA) {
+      return mon;
+    }
+    return {
+      ingredient0: AddOneIngredient(mon.ingredient0),
+      ingredient30: mon.ingredient30.map(AddOneIngredient),
+      ingredient60: mon.ingredient60.map(AddOneIngredient),
+      skillPercentage: mon.skillPercentage * 1.5,
+      ...mon,
+    };
+  },
+};
+
+export const EEVEE_WEEK: Event = {
+  name: 'Eevee Week',
+  description: 'Main skills trigger 50% more often.',
+  startDate: new Date(2023, 11, 20),
+  endDate: new Date(2023, 11, 27),
+  statModifier: (mon: Pokemon) => {
+    return {
+      skillPercentage: mon.skillPercentage * 1.5,
+      ...mon,
+    };
+  },
+};
+
+export const NO_EVENT: Event = {
+  name: 'No Event',
+  description: 'No changes.',
+  startDate: new Date(0),
+  endDate: new Date(Infinity),
+  statModifier: (mon: Pokemon) => mon,
+};
+
+export const EVENTS: Event[] = [FIRST_ANNIVERSARY_FEST, ENTEI_RESEARCH, RAIKOU_RESEARCH, EEVEE_WEEK];

--- a/common/src/domain/event/index.ts
+++ b/common/src/domain/event/index.ts
@@ -1,0 +1,1 @@
+export * from './event';

--- a/common/src/domain/index.ts
+++ b/common/src/domain/index.ts
@@ -1,5 +1,6 @@
 export * as berry from './berry';
 export * from './constants';
+export * from './event';
 export * as ingredient from './ingredient';
 export * as island from './island';
 export * as mainskill from './mainskill';

--- a/common/src/domain/types/stats.ts
+++ b/common/src/domain/types/stats.ts
@@ -1,10 +1,25 @@
 import { PokemonIngredientSet, nature, subskill } from '..';
+import { Pokemon } from '../pokemon';
 
 export interface PokemonStats {
   level: number;
   nature: nature.Nature;
   subskills: subskill.SubSkill[];
   skillLevel: number;
+}
+
+export enum IngredientList {
+  AAA = 1,
+  AAB,
+  AAC,
+  ABA,
+  ABB,
+  ABC,
+}
+
+export interface PokemonIngredientList {
+  pokemon: Pokemon;
+  ingredientList: IngredientList;
 }
 
 export interface PokemonInput {

--- a/common/src/utils/event-utils/event-utils.ts
+++ b/common/src/utils/event-utils/event-utils.ts
@@ -1,0 +1,8 @@
+import { IngredientSet } from '../../domain/types';
+
+export function AddOneIngredient(baseDrop: IngredientSet): IngredientSet {
+  return {
+    amount: baseDrop.amount + 1,
+    ingredient: baseDrop.ingredient,
+  };
+}

--- a/common/src/utils/event-utils/index.ts
+++ b/common/src/utils/event-utils/index.ts
@@ -1,0 +1,1 @@
+export * from './event-utils';

--- a/common/src/utils/index.ts
+++ b/common/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './async-utils';
+export * from './event-utils';
 export * from './ingredient-utils';
 export * from './math-utils';
 export * from './nature-utils';


### PR DESCRIPTION
This PR seeks to add events to the production calculator. In Eevee Week, Raikou Research, and Entei Research, we saw buffs to Pokemons' stats, like skill rates. These impact Pokemons' productions, so SleepAPI's production calculator ideally would support this.

We don't know what sort of events Select Button will run in the future, or how they might influence things. This PR handles event buffs with a function passed to the production calculator that modifies a Pokemon. When there's no active event, this function is simply the identity function: `(mon: Pokemon) => mon`. For other events, this function is a little more complicated. The ingredient drop boost in Raikou and Entei was complicated enough to warrant a helper function, which is in `event-util.ts`.

Another approach would be to add more inputs to the production calcualtor to handle events. So far, we've only seen a small number of changes made: increased skill rate, increased ingredient drops, and restricting bonuses to a specific type. I don't like this approach, because I think it risks making it harder to maintain the codebase as new events have new mechanics. If a future event restricts some bonuses to one type and other bonuses to another type, then we'd have to rewrite anything that assumes all bonuses will either go to all Pokemon or to only Pokemon of a specific type.

**WIP Status:**

The first commit adds the `Event` data type, and it adds the events we've seen so far. Future commits will add the ability to pass an event into the production calculator, add an event parameter to the production calculator API route, and add an API route to get a list of all events.