### PR TITLE
Refactor max carry size

### DIFF
--- a/backend/src/assets/functions.2.4.0.js
+++ b/backend/src/assets/functions.2.4.0.js
@@ -317,7 +317,7 @@ function getPokemonData(pokemonName) {
       ingredients.push(`${ing0}/${ing30_2}/${ing60_3}`); // ABC
     }
 
-    var nrOfEvolutions = (pokemonInfo.maxCarrySize - pokemonInfo.carrySize) / 5;
+    var nrOfEvolutions = pokemonInfo.previousEvolutions;
 
     populateIngredientOptions(ingredients);
     populateEvolutionData(nrOfEvolutions);

--- a/backend/src/assets/production-calculator.html
+++ b/backend/src/assets/production-calculator.html
@@ -1910,7 +1910,8 @@
                   Quiet [Ing M, Help M, Ing S]</br></br>
                   
                   Optimal berry setup: Max skill level</br>
-                  Adamant [BFS, Help M, Help S]</br></br>
+                  Adamant [BFS, Help M, Help S]</br>
+                  Never evolved</br></br>
 
                   Optimal skill setup: Max skill level</br>
                   Sassy [Skill M, Help M, Skill S]

--- a/backend/src/controllers/calculator/production.controller.ts
+++ b/backend/src/controllers/calculator/production.controller.ts
@@ -128,17 +128,18 @@ export default class ProductionController extends Controller {
     const uniqueHelperBoost = rawUniqueHelperBoost === 0 && canRollHelperBoost ? 1 : rawUniqueHelperBoost;
 
     const inputNrOfEvos = queryAsNumber(input.nrOfEvolutions);
-    const maxCarrySize = inputNrOfEvos !== undefined ? pkmn.carrySize + inputNrOfEvos * 5 : pkmn.maxCarrySize;
-    if (maxCarrySize > pkmn.maxCarrySize) {
+    const nrOfEvos = inputNrOfEvos !== undefined ? inputNrOfEvos : pkmn.previousEvolutions;
+    if (nrOfEvos > pkmn.previousEvolutions) {
       throw new PokemonError(`${pkmn.name} doesn't evolve ${inputNrOfEvos} times`);
     }
+    const inventoryLimit = pkmn.carrySize + nrOfEvos * 5;
 
     const parsedInput: ProductionStats = {
       level,
       nature: getNature(input.nature),
       subskills: extractSubskillsBasedOnLevel(level, input.subskills),
       skillLevel: Math.min(queryAsNumber(input.skillLevel) ?? pkmn.skill.maxLevel, pkmn.skill.maxLevel),
-      maxCarrySize,
+      inventoryLimit,
       e4eProcs: queryAsNumber(input.e4eProcs) ?? 0,
       e4eLevel: queryAsNumber(input.e4eLevel) ?? mainskill.ENERGY_FOR_EVERYONE.maxLevel,
       cheer: queryAsNumber(input.cheer) ?? 0,

--- a/backend/src/domain/combination/custom.ts
+++ b/backend/src/domain/combination/custom.ts
@@ -6,7 +6,7 @@ export interface CustomStats {
   nature: nature.Nature;
   subskills: subskill.SubSkill[];
   skillLevel: number;
-  maxCarrySize: number;
+  inventoryLimit: number;
 }
 
 export interface CustomPokemonCombinationWithProduce {

--- a/backend/src/domain/computed/production.ts
+++ b/backend/src/domain/computed/production.ts
@@ -7,7 +7,7 @@ export interface ProductionStats {
   nature?: nature.Nature;
   subskills?: subskill.SubSkill[];
   skillLevel?: number;
-  maxCarrySize?: number;
+  inventoryLimit?: number;
   e4eProcs: number;
   e4eLevel: number;
   cheer: number;

--- a/backend/src/public/swagger.json
+++ b/backend/src/public/swagger.json
@@ -135,7 +135,7 @@
 						"type": "number",
 						"format": "double"
 					},
-					"maxCarrySize": {
+					"inventoryLimit": {
 						"type": "number",
 						"format": "double"
 					},
@@ -361,10 +361,6 @@
 						"type": "number",
 						"format": "double"
 					},
-					"maxCarrySize": {
-						"type": "number",
-						"format": "double"
-					},
 					"previousEvolutions": {
 						"type": "number",
 						"format": "double"
@@ -400,7 +396,6 @@
 					"skillPercentage",
 					"berry",
 					"carrySize",
-					"maxCarrySize",
 					"previousEvolutions",
 					"remainingEvolutions",
 					"ingredient0",

--- a/backend/src/public/swagger.json
+++ b/backend/src/public/swagger.json
@@ -365,6 +365,10 @@
 						"type": "number",
 						"format": "double"
 					},
+					"previousEvolutions": {
+						"type": "number",
+						"format": "double"
+					},
 					"remainingEvolutions": {
 						"type": "number",
 						"format": "double"
@@ -397,6 +401,7 @@
 					"berry",
 					"carrySize",
 					"maxCarrySize",
+					"previousEvolutions",
 					"remainingEvolutions",
 					"ingredient0",
 					"ingredient30",

--- a/backend/src/services/api-service/production/production-service.ts
+++ b/backend/src/services/api-service/production/production-service.ts
@@ -5,7 +5,7 @@ import { setupAndRunProductionSimulation } from '@src/services/simulation-servic
 import { TeamSimulator } from '@src/services/simulation-service/team-simulator/team-simulator';
 import { getIngredientSet } from '@src/utils/production-utils/production-utils';
 import { limitSubSkillsToLevel } from '@src/utils/subskill-utils/subskill-utils';
-import { nature, pokemon, subskill } from 'sleepapi-common';
+import { maxCarrySize, nature, pokemon, subskill } from 'sleepapi-common';
 import { getAllIngredientCombinationsForLevel } from '../../calculator/ingredient/ingredient-calculate';
 
 export function calculatePokemonProduction(
@@ -59,7 +59,7 @@ export function calculatePokemonProduction(
         ),
         nature: nature.QUIET,
         skillLevel: pokemon.skill.maxLevel,
-        maxCarrySize: pokemon.maxCarrySize,
+        inventoryLimit: maxCarrySize(pokemon),
       },
       monteCarloIterations,
     }).detailedProduce;
@@ -80,7 +80,7 @@ export function calculatePokemonProduction(
         ),
         nature: nature.ADAMANT,
         skillLevel: pokemon.skill.maxLevel,
-        maxCarrySize: pokemon.maxCarrySize,
+        inventoryLimit: pokemon.carrySize,
       },
       monteCarloIterations,
     }).detailedProduce;
@@ -101,7 +101,7 @@ export function calculatePokemonProduction(
         ),
         nature: nature.SASSY,
         skillLevel: pokemon.skill.maxLevel,
-        maxCarrySize: pokemon.maxCarrySize,
+        inventoryLimit: maxCarrySize(pokemon),
       },
       monteCarloIterations,
     }).detailedProduce;

--- a/backend/src/services/calculator/contribution/contribution-calculator.test.ts
+++ b/backend/src/services/calculator/contribution/contribution-calculator.test.ts
@@ -10,6 +10,7 @@ import {
   curry,
   dessert,
   ingredient,
+  maxCarrySize,
   nature,
   pokemon,
   prettifyIngredientDrop,
@@ -919,7 +920,7 @@ function generateProducingPokemon(params: {
       nature: nature.QUIET,
       skillLevel: pokemon.skill.maxLevel,
       subskills: [subskill.INGREDIENT_FINDER_M, subskill.HELPING_SPEED_M, subskill.INGREDIENT_FINDER_S],
-      maxCarrySize: pokemon.maxCarrySize,
+      inventoryLimit: maxCarrySize(pokemon),
     },
     detailedProduce: {
       produce: {

--- a/backend/src/services/calculator/set-cover/calculate-set-cover.ts
+++ b/backend/src/services/calculator/set-cover/calculate-set-cover.ts
@@ -19,7 +19,7 @@ export function calculateOptimalProductionForSetCover(input: SetCoverProductionS
       nature: nature ?? optimalStats.nature,
       subskills: input.subskills ?? optimalStats.subskills,
       skillLevel: input.skillLevel ?? pokemon.skill.maxLevel,
-      maxCarrySize: optimalStats.maxCarrySize,
+      inventoryLimit: optimalStats.inventoryLimit,
     };
 
     let preGeneratedSkillActivations: SkillActivation[] | undefined = undefined;

--- a/backend/src/services/calculator/stats/stats-calculator.test.ts
+++ b/backend/src/services/calculator/stats/stats-calculator.test.ts
@@ -1,4 +1,4 @@
-import { nature, pokemon, subskill } from 'sleepapi-common';
+import { maxCarrySize, nature, pokemon, subskill } from 'sleepapi-common';
 import {
   calculateHelpSpeedSubskills,
   calculateSubskillCarrySize,
@@ -50,7 +50,7 @@ describe('getOptimalIngredientStats', () => {
       nature: nature.QUIET,
       subskills: [subskill.INGREDIENT_FINDER_M, subskill.HELPING_SPEED_M],
       skillLevel: 6,
-      maxCarrySize: pokemon.BLASTOISE.maxCarrySize,
+      inventoryLimit: maxCarrySize(pokemon.BLASTOISE),
     });
   });
 
@@ -61,7 +61,7 @@ describe('getOptimalIngredientStats', () => {
       nature: nature.SASSY,
       subskills: [subskill.SKILL_TRIGGER_M, subskill.HELPING_SPEED_M],
       skillLevel: 6,
-      maxCarrySize: pokemon.SYLVEON.maxCarrySize,
+      inventoryLimit: maxCarrySize(pokemon.SYLVEON),
     });
   });
 });

--- a/backend/src/services/calculator/stats/stats-calculator.ts
+++ b/backend/src/services/calculator/stats/stats-calculator.ts
@@ -1,6 +1,6 @@
 import { CustomStats } from '@src/domain/combination/custom';
 import { subskillsForFilter } from '@src/utils/subskill-utils/subskill-utils';
-import { MathUtils, mainskill, nature, pokemon, subskill } from 'sleepapi-common';
+import { MathUtils, mainskill, maxCarrySize, nature, pokemon, subskill } from 'sleepapi-common';
 
 export function countErbUsers(erb: number, subskills: subskill.SubSkill[]) {
   const subskillErb = subskills.some(
@@ -53,7 +53,7 @@ export function getOptimalStats(level: number, pokemon: pokemon.Pokemon): Custom
       nature: nature.SASSY,
       subskills: subskillsForFilter('skill', level, pokemon),
       skillLevel: pokemon.skill.maxLevel,
-      maxCarrySize: pokemon.maxCarrySize,
+      inventoryLimit: maxCarrySize(pokemon),
     };
   }
 
@@ -62,6 +62,6 @@ export function getOptimalStats(level: number, pokemon: pokemon.Pokemon): Custom
     nature: nature.QUIET,
     subskills: subskillsForFilter('ingredient', level, pokemon),
     skillLevel: pokemon.skill.maxLevel,
-    maxCarrySize: pokemon.maxCarrySize,
+    inventoryLimit: maxCarrySize(pokemon),
   };
 }

--- a/backend/src/services/set-cover/set-cover.test.ts
+++ b/backend/src/services/set-cover/set-cover.test.ts
@@ -8,6 +8,7 @@ import {
   berry,
   dessert,
   ingredient,
+  maxCarrySize,
   nature,
   pokemon,
   prettifyIngredientDrop,
@@ -36,7 +37,7 @@ describe('processOptimalTeamSolutions', () => {
       nature: nature.RASH,
       subskills: [],
       skillLevel: 6,
-      maxCarrySize: pokemon.PINSIR.maxCarrySize,
+      inventoryLimit: maxCarrySize(pokemon.PINSIR),
     };
 
     const detailedProduce: DetailedProduce = {
@@ -316,7 +317,7 @@ const raichu: CustomPokemonCombinationWithProduce = {
     nature: nature.QUIET,
     skillLevel: 6,
     subskills: [subskill.INGREDIENT_FINDER_M, subskill.HELPING_SPEED_M, subskill.INGREDIENT_FINDER_S],
-    maxCarrySize: pokemon.RAICHU.maxCarrySize,
+    inventoryLimit: maxCarrySize(pokemon.RAICHU),
   },
   detailedProduce: {
     produce: {
@@ -385,7 +386,7 @@ const raikou: CustomPokemonCombinationWithProduce = {
     nature: nature.QUIET,
     skillLevel: 6,
     subskills: [subskill.INGREDIENT_FINDER_M, subskill.HELPING_SPEED_M, subskill.INGREDIENT_FINDER_S],
-    maxCarrySize: pokemon.RAIKOU.maxCarrySize,
+    inventoryLimit: maxCarrySize(pokemon.RAIKOU),
   },
   detailedProduce: {
     produce: {
@@ -439,7 +440,7 @@ const vaporeon: CustomPokemonCombinationWithProduce = {
     nature: nature.QUIET,
     skillLevel: 6,
     subskills: [subskill.INGREDIENT_FINDER_M, subskill.HELPING_SPEED_M, subskill.INGREDIENT_FINDER_S],
-    maxCarrySize: pokemon.VAPOREON.maxCarrySize,
+    inventoryLimit: maxCarrySize(pokemon.VAPOREON),
   },
   detailedProduce: {
     produce: {

--- a/backend/src/services/simulation-service/monte-carlo/monte-carlo.test.ts
+++ b/backend/src/services/simulation-service/monte-carlo/monte-carlo.test.ts
@@ -1,6 +1,6 @@
 import { PokemonProduce } from '@src/domain/combination/produce';
 import { MOCKED_MAIN_SLEEP, MOCKED_POKEMON } from '@src/utils/test-utils/defaults';
-import { berry, ingredient, nature } from 'sleepapi-common';
+import { berry, ingredient, maxCarrySize, nature } from 'sleepapi-common';
 import { monteCarlo } from './monte-carlo';
 
 describe('monteCarlo', () => {
@@ -10,7 +10,7 @@ describe('monteCarlo', () => {
       helpFrequency: 1000,
       mealTimes: [],
       pokemonWithAverageProduce,
-      inventoryLimit: MOCKED_POKEMON.maxCarrySize,
+      inventoryLimit: maxCarrySize(MOCKED_POKEMON),
       recoveryEvents: [],
       skillPercentage: MOCKED_POKEMON.skillPercentage / 100,
       skillLevel: 6,

--- a/backend/src/services/simulation-service/simulation-service.ts
+++ b/backend/src/services/simulation-service/simulation-service.ts
@@ -37,6 +37,7 @@ import {
   calculateSkillPercentage,
   combineSameIngredientsInDrop,
   mainskill,
+  maxCarrySize,
   nature,
 } from 'sleepapi-common';
 import { calculateHelpSpeedBeforeEnergy } from '../calculator/help/help-calculator';
@@ -111,7 +112,7 @@ export function setupAndRunProductionSimulation(params: {
   };
 
   const inventoryLimit =
-    (input.maxCarrySize ?? averagedPokemonCombination.pokemon.maxCarrySize) +
+    (input.inventoryLimit ?? maxCarrySize(averagedPokemonCombination.pokemon)) +
     calculateSubskillCarrySize(input.subskills ?? []);
 
   const pokemonWithAverageProduce: PokemonProduce = {

--- a/backend/src/services/simulation-service/simulator/simulator.test.ts
+++ b/backend/src/services/simulation-service/simulator/simulator.test.ts
@@ -5,7 +5,7 @@ import { SummaryEvent } from '@src/domain/event/events/summary-event/summary-eve
 import { emptyBerrySet } from '@src/services/calculator/berry/berry-calculator';
 import { MOCKED_MAIN_SLEEP, MOCKED_OPTIMAL_PRODUCTION_STATS, MOCKED_POKEMON } from '@src/utils/test-utils/defaults';
 import { TimeUtils } from '@src/utils/time-utils/time-utils';
-import { berry, ingredient, mainskill, nature } from 'sleepapi-common';
+import { berry, ingredient, mainskill, maxCarrySize, nature } from 'sleepapi-common';
 import { simulation } from './simulator';
 
 describe('simulator', () => {
@@ -15,7 +15,7 @@ describe('simulator', () => {
       helpFrequency: 1000,
       input: MOCKED_OPTIMAL_PRODUCTION_STATS,
       pokemonWithAverageProduce,
-      inventoryLimit: pokemonWithAverageProduce.pokemon.maxCarrySize,
+      inventoryLimit: maxCarrySize(pokemonWithAverageProduce.pokemon),
       recoveryEvents: [new EnergyEvent({ delta: 10, description: 'some-desc', time: TimeUtils.parseTime('08:00') })],
       extraHelpfulEvents: [
         new SkillEvent({

--- a/backend/src/services/simulation-service/team-simulator/member-state.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/member-state.test.ts
@@ -16,6 +16,7 @@ const mockPokemonSet: PokemonIngredientSet = {
     ingredient60: [{ amount: 1, ingredient: ingredient.SLOWPOKE_TAIL }],
     ingredientPercentage: 20,
     maxCarrySize: 10,
+    previousEvolutions: 0,
     remainingEvolutions: 0,
     skill: mainskill.CHARGE_STRENGTH_S,
     skillPercentage: 2,

--- a/backend/src/services/simulation-service/team-simulator/member-state.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/member-state.test.ts
@@ -15,7 +15,6 @@ const mockPokemonSet: PokemonIngredientSet = {
     ingredient30: [{ amount: 1, ingredient: ingredient.SLOWPOKE_TAIL }],
     ingredient60: [{ amount: 1, ingredient: ingredient.SLOWPOKE_TAIL }],
     ingredientPercentage: 20,
-    maxCarrySize: 10,
     previousEvolutions: 0,
     remainingEvolutions: 0,
     skill: mainskill.CHARGE_STRENGTH_S,

--- a/backend/src/services/simulation-service/team-simulator/team-simulator-utils.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator-utils.test.ts
@@ -14,6 +14,7 @@ const mockPokemonSet: PokemonIngredientSet = {
     ingredient60: [{ amount: 1, ingredient: ingredient.SLOWPOKE_TAIL }],
     ingredientPercentage: 20,
     maxCarrySize: 10,
+    previousEvolutions: 0,
     remainingEvolutions: 0,
     skill: mainskill.CHARGE_STRENGTH_S,
     skillPercentage: 2,

--- a/backend/src/services/simulation-service/team-simulator/team-simulator-utils.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator-utils.test.ts
@@ -13,7 +13,6 @@ const mockPokemonSet: PokemonIngredientSet = {
     ingredient30: [{ amount: 1, ingredient: ingredient.SLOWPOKE_TAIL }],
     ingredient60: [{ amount: 1, ingredient: ingredient.SLOWPOKE_TAIL }],
     ingredientPercentage: 20,
-    maxCarrySize: 10,
     previousEvolutions: 0,
     remainingEvolutions: 0,
     skill: mainskill.CHARGE_STRENGTH_S,

--- a/backend/src/services/simulation-service/team-simulator/team-simulator.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator.test.ts
@@ -14,6 +14,7 @@ const mockPokemonSet: PokemonIngredientSet = {
     ingredient60: [{ amount: 1, ingredient: ingredient.SLOWPOKE_TAIL }],
     ingredientPercentage: 20,
     maxCarrySize: 10,
+    previousEvolutions: 0,
     remainingEvolutions: 0,
     skill: mainskill.CHARGE_STRENGTH_S,
     skillPercentage: 100,

--- a/backend/src/services/simulation-service/team-simulator/team-simulator.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator.test.ts
@@ -13,7 +13,6 @@ const mockPokemonSet: PokemonIngredientSet = {
     ingredient30: [{ amount: 1, ingredient: ingredient.SLOWPOKE_TAIL }],
     ingredient60: [{ amount: 1, ingredient: ingredient.SLOWPOKE_TAIL }],
     ingredientPercentage: 20,
-    maxCarrySize: 10,
     previousEvolutions: 0,
     remainingEvolutions: 0,
     skill: mainskill.CHARGE_STRENGTH_S,

--- a/backend/src/services/website-converter/website-converter-service.ts
+++ b/backend/src/services/website-converter/website-converter-service.ts
@@ -29,7 +29,7 @@ interface ProductionFilters {
   nature?: nature.Nature;
   subskills?: subskill.SubSkill[];
   skillLevel?: number;
-  maxCarrySize?: number;
+  inventoryLimit?: number;
   e4eProcs: number;
   e4eLevel: number;
   helperBoostProcs: number;
@@ -322,9 +322,9 @@ class WebsiteConverterServiceImpl {
         productionCombination.filters.nature?.prettyName ?? 'None'
       }\n` +
       `Main skill level: ${productionCombination.filters.skillLevel}${
-        productionCombination.filters.maxCarrySize !== undefined
+        productionCombination.filters.inventoryLimit !== undefined
           ? `, evolutions: ${
-              (productionCombination.filters.maxCarrySize -
+              (productionCombination.filters.inventoryLimit -
                 productionCombination.production.pokemonCombination.pokemon.carrySize) /
               5
             }`

--- a/backend/src/utils/optimal-utils/optimal-utils.test.ts
+++ b/backend/src/utils/optimal-utils/optimal-utils.test.ts
@@ -9,6 +9,7 @@ import {
   curry,
   dessert,
   ingredient,
+  maxCarrySize,
   nature,
   pokemon,
   salad,
@@ -40,7 +41,7 @@ describe('calculateCombinedContributions', () => {
         nature: nature.RASH,
         subskills: [],
         skillLevel: 6,
-        maxCarrySize: pokemon.PINSIR.maxCarrySize,
+        inventoryLimit: maxCarrySize(pokemon.PINSIR),
       },
     };
 
@@ -215,7 +216,7 @@ describe('removeDuplicatePokemonCombinations', () => {
         nature: nature.RASH,
         subskills: [],
         skillLevel: 6,
-        maxCarrySize: pokemon.PINSIR.maxCarrySize,
+        inventoryLimit: maxCarrySize(pokemon.PINSIR),
       },
       detailedProduce: {
         produce: {

--- a/backend/src/utils/set-cover-utils/set-cover-utils.test.ts
+++ b/backend/src/utils/set-cover-utils/set-cover-utils.test.ts
@@ -2,7 +2,16 @@ import { CustomPokemonCombinationWithProduce } from '@src/domain/combination/cus
 import { emptyBerrySet } from '@src/services/calculator/berry/berry-calculator';
 import { SimplifiedIngredientSet } from '@src/services/set-cover/set-cover';
 import { InventoryUtils } from '@src/utils/inventory-utils/inventory-utils';
-import { berry, ingredient, mainskill, nature, pokemon, prettifyIngredientDrop, subskill } from 'sleepapi-common';
+import {
+  berry,
+  ingredient,
+  mainskill,
+  maxCarrySize,
+  nature,
+  pokemon,
+  prettifyIngredientDrop,
+  subskill,
+} from 'sleepapi-common';
 import { MOCKED_POKEMON_WITH_PRODUCE } from '../test-utils/defaults';
 import {
   calculateHelperBoostIngredientsIncrease,
@@ -55,7 +64,7 @@ describe('createPokemonByIngredientReverseIndex', () => {
           nature: nature.RASH,
           subskills: [],
           skillLevel: 6,
-          maxCarrySize: pokemon.DRATINI.maxCarrySize,
+          inventoryLimit: maxCarrySize(pokemon.DRATINI),
         },
       },
     ];
@@ -93,7 +102,7 @@ describe('createPokemonByIngredientReverseIndex', () => {
           nature: nature.RASH,
           subskills: [],
           skillLevel: 6,
-          maxCarrySize: pokemon.PINSIR.maxCarrySize,
+          inventoryLimit: maxCarrySize(pokemon.PINSIR),
         },
       },
       {
@@ -120,7 +129,7 @@ describe('createPokemonByIngredientReverseIndex', () => {
           nature: nature.RASH,
           subskills: [],
           skillLevel: 6,
-          maxCarrySize: pokemon.DELIBIRD.maxCarrySize,
+          inventoryLimit: maxCarrySize(pokemon.DELIBIRD),
         },
       },
     ];
@@ -163,7 +172,7 @@ describe('createPokemonByIngredientReverseIndex', () => {
           nature: nature.RASH,
           subskills: [],
           skillLevel: 6,
-          maxCarrySize: pokemon.DELIBIRD.maxCarrySize,
+          inventoryLimit: maxCarrySize(pokemon.DELIBIRD),
         },
       },
     ];
@@ -198,7 +207,7 @@ describe('createPokemonByIngredientReverseIndex', () => {
           nature: nature.RASH,
           subskills: [],
           skillLevel: 6,
-          maxCarrySize: pokemon.RAIKOU.maxCarrySize,
+          inventoryLimit: maxCarrySize(pokemon.RAIKOU),
         },
       },
     ];
@@ -601,7 +610,7 @@ const raichu: CustomPokemonCombinationWithProduce = {
     nature: nature.QUIET,
     skillLevel: 6,
     subskills: [subskill.INGREDIENT_FINDER_M, subskill.HELPING_SPEED_M, subskill.INGREDIENT_FINDER_S],
-    maxCarrySize: pokemon.RAICHU.maxCarrySize,
+    inventoryLimit: maxCarrySize(pokemon.RAICHU),
   },
   detailedProduce: {
     produce: {
@@ -670,7 +679,7 @@ const raikou: CustomPokemonCombinationWithProduce = {
     nature: nature.QUIET,
     skillLevel: 6,
     subskills: [subskill.INGREDIENT_FINDER_M, subskill.HELPING_SPEED_M, subskill.INGREDIENT_FINDER_S],
-    maxCarrySize: pokemon.RAIKOU.maxCarrySize,
+    inventoryLimit: maxCarrySize(pokemon.RAIKOU),
   },
   detailedProduce: {
     produce: {

--- a/backend/src/utils/simulation-utils/simulation-utils.test.ts
+++ b/backend/src/utils/simulation-utils/simulation-utils.test.ts
@@ -4,7 +4,7 @@ import { EnergyEvent } from '@src/domain/event/events/energy-event/energy-event'
 import { SkillActivation } from '@src/domain/event/events/skill-event/skill-event';
 import { Summary } from '@src/domain/event/events/summary-event/summary-event';
 import { SleepInfo } from '@src/domain/sleep/sleep-info';
-import { mainskill, nature, pokemon } from 'sleepapi-common';
+import { mainskill, maxCarrySize, nature, pokemon } from 'sleepapi-common';
 import { MOCKED_MAIN_SLEEP, MOCKED_OPTIMAL_PRODUCTION_STATS, MOCKED_PRODUCE } from '../test-utils/defaults';
 import { finishSimulation, rollRandomChance, startDayAndEnergy, startNight } from './simulation-utils';
 
@@ -22,9 +22,9 @@ describe('startDayAndEnergy', () => {
     const recoveryEvents: EnergyEvent[] = [];
     const skillActivations: SkillActivation[] = [];
 
-    expect(startDayAndEnergy(dayInfo, pkmn, input, pkmn.maxCarrySize, recoveryEvents, skillActivations, eventLog)).toBe(
-      100
-    );
+    expect(
+      startDayAndEnergy(dayInfo, pkmn, input, maxCarrySize(pkmn), recoveryEvents, skillActivations, eventLog)
+    ).toBe(100);
     expect(eventLog).toHaveLength(6);
   });
 });

--- a/backend/src/utils/subskill-utils/subskill-utils.ts
+++ b/backend/src/utils/subskill-utils/subskill-utils.ts
@@ -94,7 +94,7 @@ export function subskillsForFilter(
     );
   }
 
-  const singleStageLevel60 = pokemon.carrySize === pokemon.maxCarrySize && level >= 60;
+  const singleStageLevel60 = pokemon.previousEvolutions === 0 && level >= 60;
   const subskills = singleStageLevel60 ? singleStageSubskillsLevel60 : optimalSubskills;
 
   return limitSubSkillsToLevel(subskills, level);

--- a/backend/src/utils/test-utils/defaults.ts
+++ b/backend/src/utils/test-utils/defaults.ts
@@ -73,6 +73,7 @@ export const MOCKED_POKEMON: pokemon.Pokemon = {
   ],
   ingredientPercentage: 20,
   maxCarrySize: 20,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   name: 'MOCK_POKEMON',
   skill: mainskill.CHARGE_STRENGTH_M,

--- a/backend/src/utils/test-utils/defaults.ts
+++ b/backend/src/utils/test-utils/defaults.ts
@@ -3,7 +3,7 @@ import { Produce } from '@src/domain/combination/produce';
 import { ProductionStats } from '@src/domain/computed/production';
 import { TimePeriod } from '@src/domain/time/time';
 import { InventoryUtils } from '@src/utils/inventory-utils/inventory-utils';
-import { berry, ingredient, mainskill, nature, pokemon, subskill } from 'sleepapi-common';
+import { berry, ingredient, mainskill, maxCarrySize, nature, pokemon, subskill } from 'sleepapi-common';
 
 export const MOCKED_MAIN_SLEEP: TimePeriod = {
   start: {
@@ -72,7 +72,6 @@ export const MOCKED_POKEMON: pokemon.Pokemon = {
     },
   ],
   ingredientPercentage: 20,
-  maxCarrySize: 20,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   name: 'MOCK_POKEMON',
@@ -117,6 +116,6 @@ export const MOCKED_POKEMON_WITH_PRODUCE: CustomPokemonCombinationWithProduce = 
     nature: nature.RASH,
     subskills: [],
     skillLevel: 6,
-    maxCarrySize: pokemon.PINSIR.maxCarrySize,
+    inventoryLimit: maxCarrySize(pokemon.PINSIR),
   },
 };

--- a/common/src/domain/pokemon/berry-pokemon.ts
+++ b/common/src/domain/pokemon/berry-pokemon.ts
@@ -54,6 +54,7 @@ export const CATERPIE: Pokemon = {
   berry: LUM,
   carrySize: 11,
   maxCarrySize: 11,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: HONEY },
   ingredient30: [
@@ -97,6 +98,7 @@ export const RATTATA: Pokemon = {
   berry: PERSIM,
   carrySize: 10,
   maxCarrySize: 10,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
   ingredient30: [
@@ -130,6 +132,7 @@ export const EKANS: Pokemon = {
   berry: CHESTO,
   carrySize: 10,
   maxCarrySize: 10,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: BEAN_SAUSAGE },
   ingredient30: [
@@ -163,6 +166,7 @@ export const PIKACHU: Pokemon = {
   berry: GREPA,
   carrySize: 17,
   maxCarrySize: 22,
+  previousEvolutions: 1,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
   ingredient30: [
@@ -186,6 +190,7 @@ export const PIKACHU_HALLOWEEN: Pokemon = {
   berry: GREPA,
   carrySize: 18,
   maxCarrySize: 18,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
   ingredient30: [
@@ -219,6 +224,7 @@ export const CLEFAIRY: Pokemon = {
   berry: PECHA,
   carrySize: 16,
   maxCarrySize: 21,
+  previousEvolutions: 1,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
   ingredient30: [
@@ -252,6 +258,7 @@ export const VULPIX: Pokemon = {
   berry: LEPPA,
   carrySize: 13,
   maxCarrySize: 13,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: GREENGRASS_SOYBEANS },
   ingredient30: [
@@ -285,6 +292,7 @@ export const MANKEY: Pokemon = {
   berry: CHERI,
   carrySize: 7,
   maxCarrySize: 7,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: BEAN_SAUSAGE },
   ingredient30: [
@@ -318,6 +326,7 @@ export const DODUO: Pokemon = {
   berry: PAMTRE,
   carrySize: 13,
   maxCarrySize: 13,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: GREENGRASS_SOYBEANS },
   ingredient30: [
@@ -351,6 +360,7 @@ export const ONIX: Pokemon = {
   berry: SITRUS,
   carrySize: 22,
   maxCarrySize: 22,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: SNOOZY_TOMATO },
   ingredient30: [
@@ -374,6 +384,7 @@ export const CUBONE: Pokemon = {
   berry: FIGY,
   carrySize: 10,
   maxCarrySize: 10,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: WARMING_GINGER },
   ingredient30: [
@@ -406,6 +417,7 @@ export const CHIKORITA: Pokemon = {
   berry: DURIN,
   carrySize: 12,
   maxCarrySize: 12,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: SOOTHING_CACAO },
   ingredient30: [
@@ -449,6 +461,7 @@ export const CYNDAQUIL: Pokemon = {
   berry: LEPPA,
   carrySize: 14,
   maxCarrySize: 14,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: WARMING_GINGER },
   ingredient30: [
@@ -492,6 +505,7 @@ export const TOTODILE: Pokemon = {
   berry: ORAN,
   carrySize: 11,
   maxCarrySize: 11,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: BEAN_SAUSAGE },
   ingredient30: [
@@ -565,6 +579,7 @@ export const HOUNDOUR: Pokemon = {
   berry: WIKI,
   carrySize: 10,
   maxCarrySize: 10,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: FIERY_HERB },
   ingredient30: [
@@ -598,6 +613,7 @@ export const SLAKOTH: Pokemon = {
   berry: PERSIM,
   carrySize: 7,
   maxCarrySize: 7,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: SNOOZY_TOMATO },
   ingredient30: [
@@ -641,6 +657,7 @@ export const SWABLU: Pokemon = {
   berry: PAMTRE,
   carrySize: 12,
   maxCarrySize: 12,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: FANCY_EGG },
   ingredient30: [
@@ -675,6 +692,7 @@ export const SHUPPET: Pokemon = {
   berry: BLUK,
   carrySize: 11,
   maxCarrySize: 11,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: PURE_OIL },
   ingredient30: [
@@ -708,6 +726,7 @@ export const SPHEAL: Pokemon = {
   berry: RAWST,
   carrySize: 9,
   maxCarrySize: 9,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: PURE_OIL },
   ingredient30: [

--- a/common/src/domain/pokemon/berry-pokemon.ts
+++ b/common/src/domain/pokemon/berry-pokemon.ts
@@ -53,7 +53,6 @@ export const CATERPIE: Pokemon = {
   skillPercentage: 0.8,
   berry: LUM,
   carrySize: 11,
-  maxCarrySize: 11,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: HONEY },
@@ -76,7 +75,6 @@ export const METAPOD: Pokemon = {
   ingredientPercentage: 20.8,
   skillPercentage: 1.8,
   carrySize: 13,
-  maxCarrySize: 18,
 };
 
 export const BUTTERFREE: Pokemon = {
@@ -86,7 +84,6 @@ export const BUTTERFREE: Pokemon = {
   ingredientPercentage: 19.7,
   skillPercentage: 1.4,
   carrySize: 21,
-  maxCarrySize: 31,
 };
 
 export const RATTATA: Pokemon = {
@@ -97,7 +94,6 @@ export const RATTATA: Pokemon = {
   skillPercentage: 3.0,
   berry: PERSIM,
   carrySize: 10,
-  maxCarrySize: 10,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
@@ -120,7 +116,6 @@ export const RATICATE: Pokemon = {
   ingredientPercentage: 23.7,
   skillPercentage: 3.0,
   carrySize: 16,
-  maxCarrySize: 21,
 };
 
 export const EKANS: Pokemon = {
@@ -131,7 +126,6 @@ export const EKANS: Pokemon = {
   skillPercentage: 3.3,
   berry: CHESTO,
   carrySize: 10,
-  maxCarrySize: 10,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: BEAN_SAUSAGE },
@@ -154,7 +148,6 @@ export const ARBOK: Pokemon = {
   ingredientPercentage: 26.4,
   skillPercentage: 5.7,
   carrySize: 14,
-  maxCarrySize: 19,
 };
 
 export const PIKACHU: Pokemon = {
@@ -165,7 +158,6 @@ export const PIKACHU: Pokemon = {
   skillPercentage: 2.1,
   berry: GREPA,
   carrySize: 17,
-  maxCarrySize: 22,
   previousEvolutions: 1,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
@@ -189,7 +181,6 @@ export const PIKACHU_HALLOWEEN: Pokemon = {
   skillPercentage: 2.1,
   berry: GREPA,
   carrySize: 18,
-  maxCarrySize: 18,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
@@ -212,7 +203,6 @@ export const RAICHU: Pokemon = {
   ingredientPercentage: 22.4,
   skillPercentage: 3.2,
   carrySize: 21,
-  maxCarrySize: 31,
 };
 
 export const CLEFAIRY: Pokemon = {
@@ -223,7 +213,6 @@ export const CLEFAIRY: Pokemon = {
   skillPercentage: 3.6,
   berry: PECHA,
   carrySize: 16,
-  maxCarrySize: 21,
   previousEvolutions: 1,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
@@ -246,7 +235,6 @@ export const CLEFABLE: Pokemon = {
   ingredientPercentage: 16.8,
   skillPercentage: 3.6,
   carrySize: 24,
-  maxCarrySize: 34,
 };
 
 export const VULPIX: Pokemon = {
@@ -257,7 +245,6 @@ export const VULPIX: Pokemon = {
   skillPercentage: 2.7,
   berry: LEPPA,
   carrySize: 13,
-  maxCarrySize: 13,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: GREENGRASS_SOYBEANS },
@@ -280,7 +267,6 @@ export const NINETALES: Pokemon = {
   ingredientPercentage: 16.4,
   skillPercentage: 2.5,
   carrySize: 23,
-  maxCarrySize: 28,
 };
 
 export const MANKEY: Pokemon = {
@@ -291,7 +277,6 @@ export const MANKEY: Pokemon = {
   skillPercentage: 2.2,
   berry: CHERI,
   carrySize: 7,
-  maxCarrySize: 7,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: BEAN_SAUSAGE },
@@ -314,7 +299,6 @@ export const PRIMEAPE: Pokemon = {
   ingredientPercentage: 20.0,
   skillPercentage: 2.4,
   carrySize: 17,
-  maxCarrySize: 22,
 };
 
 export const DODUO: Pokemon = {
@@ -325,7 +309,6 @@ export const DODUO: Pokemon = {
   skillPercentage: 2.0,
   berry: PAMTRE,
   carrySize: 13,
-  maxCarrySize: 13,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: GREENGRASS_SOYBEANS },
@@ -348,7 +331,6 @@ export const DODRIO: Pokemon = {
   ingredientPercentage: 18.4,
   skillPercentage: 2.0,
   carrySize: 21,
-  maxCarrySize: 26,
 };
 
 export const ONIX: Pokemon = {
@@ -359,7 +341,6 @@ export const ONIX: Pokemon = {
   skillPercentage: 2.3,
   berry: SITRUS,
   carrySize: 22,
-  maxCarrySize: 22,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: SNOOZY_TOMATO },
@@ -383,7 +364,6 @@ export const CUBONE: Pokemon = {
   skillPercentage: 4.4,
   berry: FIGY,
   carrySize: 10,
-  maxCarrySize: 10,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: WARMING_GINGER },
@@ -405,7 +385,6 @@ export const MAROWAK: Pokemon = {
   ingredientPercentage: 22.5,
   skillPercentage: 4.5,
   carrySize: 15,
-  maxCarrySize: 20,
 };
 
 export const CHIKORITA: Pokemon = {
@@ -416,7 +395,6 @@ export const CHIKORITA: Pokemon = {
   skillPercentage: 3.9,
   berry: DURIN,
   carrySize: 12,
-  maxCarrySize: 12,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: SOOTHING_CACAO },
@@ -439,7 +417,6 @@ export const BAYLEEF: Pokemon = {
   ingredientPercentage: 16.8,
   skillPercentage: 3.8,
   carrySize: 17,
-  maxCarrySize: 22,
 };
 
 export const MEGANIUM: Pokemon = {
@@ -449,7 +426,6 @@ export const MEGANIUM: Pokemon = {
   ingredientPercentage: 17.5,
   skillPercentage: 4.6,
   carrySize: 20,
-  maxCarrySize: 30,
 };
 
 export const CYNDAQUIL: Pokemon = {
@@ -460,7 +436,6 @@ export const CYNDAQUIL: Pokemon = {
   skillPercentage: 2.1,
   berry: LEPPA,
   carrySize: 14,
-  maxCarrySize: 14,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: WARMING_GINGER },
@@ -483,7 +458,6 @@ export const QUILAVA: Pokemon = {
   ingredientPercentage: 21.1,
   skillPercentage: 4.1,
   carrySize: 18,
-  maxCarrySize: 23,
 };
 
 export const TYPHLOSION: Pokemon = {
@@ -493,7 +467,6 @@ export const TYPHLOSION: Pokemon = {
   ingredientPercentage: 20.8,
   skillPercentage: 3.9,
   carrySize: 23,
-  maxCarrySize: 33,
 };
 
 export const TOTODILE: Pokemon = {
@@ -504,7 +477,6 @@ export const TOTODILE: Pokemon = {
   skillPercentage: 5.2,
   berry: ORAN,
   carrySize: 11,
-  maxCarrySize: 11,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: BEAN_SAUSAGE },
@@ -526,7 +498,6 @@ export const CROCONAW: Pokemon = {
   ingredientPercentage: 25.3,
   skillPercentage: 5.2,
   carrySize: 15,
-  maxCarrySize: 20,
 };
 
 export const FERALIGATR: Pokemon = {
@@ -536,7 +507,6 @@ export const FERALIGATR: Pokemon = {
   ingredientPercentage: 25.7,
   skillPercentage: 5.5,
   carrySize: 19,
-  maxCarrySize: 29,
 };
 
 export const PICHU: Pokemon = {
@@ -546,7 +516,6 @@ export const PICHU: Pokemon = {
   ingredientPercentage: 21.0,
   skillPercentage: 2.3,
   carrySize: 10,
-  maxCarrySize: 10,
 };
 
 export const CLEFFA: Pokemon = {
@@ -556,7 +525,6 @@ export const CLEFFA: Pokemon = {
   ingredientPercentage: 16.4,
   skillPercentage: 3.4,
   carrySize: 10,
-  maxCarrySize: 10,
 };
 
 export const STEELIX: Pokemon = {
@@ -567,7 +535,6 @@ export const STEELIX: Pokemon = {
   skillPercentage: 3.2,
   berry: BELUE,
   carrySize: 25,
-  maxCarrySize: 30,
 };
 
 export const HOUNDOUR: Pokemon = {
@@ -578,7 +545,6 @@ export const HOUNDOUR: Pokemon = {
   skillPercentage: 4.4,
   berry: WIKI,
   carrySize: 10,
-  maxCarrySize: 10,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: FIERY_HERB },
@@ -601,7 +567,6 @@ export const HOUNDOOM: Pokemon = {
   ingredientPercentage: 20.3,
   skillPercentage: 4.6,
   carrySize: 16,
-  maxCarrySize: 21,
 };
 
 export const SLAKOTH: Pokemon = {
@@ -612,7 +577,6 @@ export const SLAKOTH: Pokemon = {
   skillPercentage: 1.9,
   berry: PERSIM,
   carrySize: 7,
-  maxCarrySize: 7,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: SNOOZY_TOMATO },
@@ -635,7 +599,6 @@ export const VIGOROTH: Pokemon = {
   ingredientPercentage: 20.4,
   skillPercentage: 1.5,
   carrySize: 9,
-  maxCarrySize: 14,
 };
 
 export const SLAKING: Pokemon = {
@@ -645,7 +608,6 @@ export const SLAKING: Pokemon = {
   ingredientPercentage: 33.9,
   skillPercentage: 6.7,
   carrySize: 12,
-  maxCarrySize: 22,
 };
 
 export const SWABLU: Pokemon = {
@@ -656,7 +618,6 @@ export const SWABLU: Pokemon = {
   skillPercentage: 3.2,
   berry: PAMTRE,
   carrySize: 12,
-  maxCarrySize: 12,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: FANCY_EGG },
@@ -680,7 +641,6 @@ export const ALTARIA: Pokemon = {
   skillPercentage: 6.1,
   berry: YACHE,
   carrySize: 14,
-  maxCarrySize: 19,
 };
 
 export const SHUPPET: Pokemon = {
@@ -691,7 +651,6 @@ export const SHUPPET: Pokemon = {
   skillPercentage: 2.6,
   berry: BLUK,
   carrySize: 11,
-  maxCarrySize: 11,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: PURE_OIL },
@@ -714,7 +673,6 @@ export const BANETTE: Pokemon = {
   ingredientPercentage: 17.9,
   skillPercentage: 3.3,
   carrySize: 19,
-  maxCarrySize: 24,
 };
 
 export const SPHEAL: Pokemon = {
@@ -725,7 +683,6 @@ export const SPHEAL: Pokemon = {
   skillPercentage: 2.3,
   berry: RAWST,
   carrySize: 9,
-  maxCarrySize: 9,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: PURE_OIL },
@@ -748,7 +705,6 @@ export const SEALEO: Pokemon = {
   ingredientPercentage: 22.1,
   skillPercentage: 2.1,
   carrySize: 13,
-  maxCarrySize: 18,
 };
 
 export const WALREIN: Pokemon = {
@@ -758,7 +714,6 @@ export const WALREIN: Pokemon = {
   ingredientPercentage: 22.3,
   skillPercentage: 2.2,
   carrySize: 18,
-  maxCarrySize: 28,
 };
 
 export const OPTIMAL_BERRY_SPECIALISTS: Pokemon[] = [

--- a/common/src/domain/pokemon/ingredient-pokemon.ts
+++ b/common/src/domain/pokemon/ingredient-pokemon.ts
@@ -57,6 +57,7 @@ export const BULBASAUR: Pokemon = {
   berry: DURIN,
   carrySize: 11,
   maxCarrySize: 11,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: HONEY },
   ingredient30: [
@@ -100,6 +101,7 @@ export const CHARMANDER: Pokemon = {
   berry: LEPPA,
   carrySize: 12,
   maxCarrySize: 12,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: BEAN_SAUSAGE },
   ingredient30: [
@@ -143,6 +145,7 @@ export const SQUIRTLE: Pokemon = {
   berry: ORAN,
   carrySize: 10,
   maxCarrySize: 10,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: MOOMOO_MILK },
   ingredient30: [
@@ -186,6 +189,7 @@ export const DIGLETT: Pokemon = {
   berry: FIGY,
   carrySize: 10,
   maxCarrySize: 10,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 2, ingredient: SNOOZY_TOMATO },
   ingredient30: [
@@ -219,6 +223,7 @@ export const BELLSPROUT: Pokemon = {
   berry: DURIN,
   carrySize: 8,
   maxCarrySize: 8,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: SNOOZY_TOMATO },
   ingredient30: [
@@ -262,6 +267,7 @@ export const GEODUDE: Pokemon = {
   berry: SITRUS,
   carrySize: 9,
   maxCarrySize: 9,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: GREENGRASS_SOYBEANS },
   ingredient30: [
@@ -305,6 +311,7 @@ export const GASTLY: Pokemon = {
   berry: BLUK,
   carrySize: 10,
   maxCarrySize: 10,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: FIERY_HERB },
   ingredient30: [
@@ -348,6 +355,7 @@ export const KANGASKHAN: Pokemon = {
   berry: PERSIM,
   carrySize: 18,
   maxCarrySize: 18,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: WARMING_GINGER },
   ingredient30: [
@@ -371,6 +379,7 @@ export const MR_MIME: Pokemon = {
   berry: MAGO,
   carrySize: 17,
   maxCarrySize: 22,
+  previousEvolutions: 1,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: SNOOZY_TOMATO },
   ingredient30: [
@@ -394,6 +403,7 @@ export const PINSIR: Pokemon = {
   berry: LUM,
   carrySize: 24,
   maxCarrySize: 24,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: HONEY },
   ingredient30: [
@@ -417,6 +427,7 @@ export const DITTO: Pokemon = {
   berry: PERSIM,
   carrySize: 17,
   maxCarrySize: 17,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: PURE_OIL },
   ingredient30: [
@@ -440,6 +451,7 @@ export const DRATINI: Pokemon = {
   berry: YACHE,
   carrySize: 9,
   maxCarrySize: 9,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: FIERY_HERB },
   ingredient30: [
@@ -483,6 +495,7 @@ export const DELIBIRD: Pokemon = {
   berry: PAMTRE,
   carrySize: 20,
   maxCarrySize: 20,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: FANCY_EGG },
   ingredient30: [
@@ -506,6 +519,7 @@ export const LARVITAR: Pokemon = {
   berry: SITRUS,
   carrySize: 9,
   maxCarrySize: 9,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: WARMING_GINGER },
   ingredient30: [
@@ -550,6 +564,7 @@ export const ABSOL: Pokemon = {
   berry: WIKI,
   carrySize: 18,
   maxCarrySize: 18,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: SOOTHING_CACAO },
   ingredient30: [
@@ -583,6 +598,7 @@ export const CROAGUNK: Pokemon = {
   berry: CHESTO,
   carrySize: 10,
   maxCarrySize: 10,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 2, ingredient: PURE_OIL },
   ingredient30: [
@@ -615,6 +631,7 @@ export const SNOVER: Pokemon = {
   berry: RAWST,
   carrySize: 10,
   maxCarrySize: 10,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 2, ingredient: SNOOZY_TOMATO },
   ingredient30: [
@@ -648,6 +665,7 @@ export const STUFFUL: Pokemon = {
   berry: CHERI,
   carrySize: 13,
   maxCarrySize: 13,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 2, ingredient: GREENGRASS_CORN },
   ingredient30: [
@@ -681,6 +699,7 @@ export const COMFEY: Pokemon = {
   berry: PECHA,
   carrySize: 20,
   maxCarrySize: 20,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: GREENGRASS_CORN },
   ingredient30: [
@@ -704,6 +723,7 @@ export const CRAMORANT: Pokemon = {
   berry: PAMTRE,
   carrySize: 19,
   maxCarrySize: 19,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: PURE_OIL },
   ingredient30: [
@@ -727,6 +747,7 @@ export const SPRIGATITO: Pokemon = {
   berry: DURIN,
   carrySize: 10,
   maxCarrySize: 10,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: SOFT_POTATO },
   ingredient30: [
@@ -771,6 +792,7 @@ export const FUECOCO: Pokemon = {
   berry: LEPPA,
   carrySize: 11,
   maxCarrySize: 11,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: FANCY_APPLE },
   ingredient30: [
@@ -815,6 +837,7 @@ export const QUAXLY: Pokemon = {
   berry: ORAN,
   carrySize: 10,
   maxCarrySize: 10,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: GREENGRASS_SOYBEANS },
   ingredient30: [

--- a/common/src/domain/pokemon/ingredient-pokemon.ts
+++ b/common/src/domain/pokemon/ingredient-pokemon.ts
@@ -56,7 +56,6 @@ export const BULBASAUR: Pokemon = {
   skillPercentage: 1.9,
   berry: DURIN,
   carrySize: 11,
-  maxCarrySize: 11,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: HONEY },
@@ -79,7 +78,6 @@ export const IVYSAUR: Pokemon = {
   ingredientPercentage: 25.5,
   skillPercentage: 1.9,
   carrySize: 14,
-  maxCarrySize: 19,
 };
 
 export const VENUSAUR: Pokemon = {
@@ -89,7 +87,6 @@ export const VENUSAUR: Pokemon = {
   ingredientPercentage: 26.6,
   skillPercentage: 2.1,
   carrySize: 17,
-  maxCarrySize: 27,
 };
 
 export const CHARMANDER: Pokemon = {
@@ -100,7 +97,6 @@ export const CHARMANDER: Pokemon = {
   skillPercentage: 1.1,
   berry: LEPPA,
   carrySize: 12,
-  maxCarrySize: 12,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: BEAN_SAUSAGE },
@@ -123,7 +119,6 @@ export const CHARMELEON: Pokemon = {
   ingredientPercentage: 22.7,
   skillPercentage: 1.6,
   carrySize: 15,
-  maxCarrySize: 20,
 };
 
 export const CHARIZARD: Pokemon = {
@@ -133,7 +128,6 @@ export const CHARIZARD: Pokemon = {
   ingredientPercentage: 22.4,
   skillPercentage: 1.6,
   carrySize: 19,
-  maxCarrySize: 29,
 };
 
 export const SQUIRTLE: Pokemon = {
@@ -144,7 +138,6 @@ export const SQUIRTLE: Pokemon = {
   skillPercentage: 2.0,
   berry: ORAN,
   carrySize: 10,
-  maxCarrySize: 10,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: MOOMOO_MILK },
@@ -167,7 +160,6 @@ export const WARTORTLE: Pokemon = {
   ingredientPercentage: 27.1,
   skillPercentage: 2.0,
   carrySize: 14,
-  maxCarrySize: 19,
 };
 
 export const BLASTOISE: Pokemon = {
@@ -177,7 +169,6 @@ export const BLASTOISE: Pokemon = {
   ingredientPercentage: 27.5,
   skillPercentage: 2.1,
   carrySize: 17,
-  maxCarrySize: 27,
 };
 
 export const DIGLETT: Pokemon = {
@@ -188,7 +179,6 @@ export const DIGLETT: Pokemon = {
   skillPercentage: 2.1,
   berry: FIGY,
   carrySize: 10,
-  maxCarrySize: 10,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 2, ingredient: SNOOZY_TOMATO },
@@ -211,7 +201,6 @@ export const DUGTRIO: Pokemon = {
   ingredientPercentage: 19.0,
   skillPercentage: 2.0,
   carrySize: 16,
-  maxCarrySize: 21,
 };
 
 export const BELLSPROUT: Pokemon = {
@@ -222,7 +211,6 @@ export const BELLSPROUT: Pokemon = {
   skillPercentage: 3.9,
   berry: DURIN,
   carrySize: 8,
-  maxCarrySize: 8,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: SNOOZY_TOMATO },
@@ -245,7 +233,6 @@ export const WEEPINBELL: Pokemon = {
   ingredientPercentage: 23.5,
   skillPercentage: 4.0,
   carrySize: 12,
-  maxCarrySize: 17,
 };
 
 export const VICTREEBEL: Pokemon = {
@@ -255,7 +242,6 @@ export const VICTREEBEL: Pokemon = {
   ingredientPercentage: 23.3,
   skillPercentage: 3.9,
   carrySize: 17,
-  maxCarrySize: 27,
 };
 
 export const GEODUDE: Pokemon = {
@@ -266,7 +252,6 @@ export const GEODUDE: Pokemon = {
   skillPercentage: 5.2,
   berry: SITRUS,
   carrySize: 9,
-  maxCarrySize: 9,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: GREENGRASS_SOYBEANS },
@@ -289,7 +274,6 @@ export const GRAVELER: Pokemon = {
   ingredientPercentage: 27.2,
   skillPercentage: 4.8,
   carrySize: 12,
-  maxCarrySize: 17,
 };
 
 export const GOLEM: Pokemon = {
@@ -299,7 +283,6 @@ export const GOLEM: Pokemon = {
   ingredientPercentage: 28.0,
   skillPercentage: 5.2,
   carrySize: 16,
-  maxCarrySize: 26,
 };
 
 export const GASTLY: Pokemon = {
@@ -310,7 +293,6 @@ export const GASTLY: Pokemon = {
   skillPercentage: 1.5,
   berry: BLUK,
   carrySize: 10,
-  maxCarrySize: 10,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: FIERY_HERB },
@@ -333,7 +315,6 @@ export const HAUNTER: Pokemon = {
   ingredientPercentage: 15.7,
   skillPercentage: 2.2,
   carrySize: 14,
-  maxCarrySize: 19,
 };
 
 export const GENGAR: Pokemon = {
@@ -343,7 +324,6 @@ export const GENGAR: Pokemon = {
   ingredientPercentage: 16.1,
   skillPercentage: 2.4,
   carrySize: 18,
-  maxCarrySize: 28,
 };
 
 export const KANGASKHAN: Pokemon = {
@@ -354,7 +334,6 @@ export const KANGASKHAN: Pokemon = {
   skillPercentage: 1.7,
   berry: PERSIM,
   carrySize: 18,
-  maxCarrySize: 18,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: WARMING_GINGER },
@@ -378,7 +357,6 @@ export const MR_MIME: Pokemon = {
   skillPercentage: 3.9,
   berry: MAGO,
   carrySize: 17,
-  maxCarrySize: 22,
   previousEvolutions: 1,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: SNOOZY_TOMATO },
@@ -402,7 +380,6 @@ export const PINSIR: Pokemon = {
   skillPercentage: 3.1,
   berry: LUM,
   carrySize: 24,
-  maxCarrySize: 24,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: HONEY },
@@ -426,7 +403,6 @@ export const DITTO: Pokemon = {
   skillPercentage: 3.6,
   berry: PERSIM,
   carrySize: 17,
-  maxCarrySize: 17,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: PURE_OIL },
@@ -450,7 +426,6 @@ export const DRATINI: Pokemon = {
   skillPercentage: 2.0,
   berry: YACHE,
   carrySize: 9,
-  maxCarrySize: 9,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: FIERY_HERB },
@@ -473,7 +448,6 @@ export const DRAGONAIR: Pokemon = {
   ingredientPercentage: 26.2,
   skillPercentage: 2.5,
   carrySize: 12,
-  maxCarrySize: 17,
 };
 
 export const DRAGONITE: Pokemon = {
@@ -483,7 +457,6 @@ export const DRAGONITE: Pokemon = {
   ingredientPercentage: 26.4,
   skillPercentage: 2.6,
   carrySize: 20,
-  maxCarrySize: 30,
 };
 
 export const DELIBIRD: Pokemon = {
@@ -494,7 +467,6 @@ export const DELIBIRD: Pokemon = {
   skillPercentage: 1.5,
   berry: PAMTRE,
   carrySize: 20,
-  maxCarrySize: 20,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: FANCY_EGG },
@@ -518,7 +490,6 @@ export const LARVITAR: Pokemon = {
   skillPercentage: 4.1,
   berry: SITRUS,
   carrySize: 9,
-  maxCarrySize: 9,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: WARMING_GINGER },
@@ -541,7 +512,6 @@ export const PUPITAR: Pokemon = {
   ingredientPercentage: 24.7,
   skillPercentage: 4.5,
   carrySize: 13,
-  maxCarrySize: 18,
 };
 
 export const TYRANITAR: Pokemon = {
@@ -552,7 +522,6 @@ export const TYRANITAR: Pokemon = {
   skillPercentage: 5.2,
   berry: WIKI,
   carrySize: 19,
-  maxCarrySize: 29,
 };
 
 export const ABSOL: Pokemon = {
@@ -563,7 +532,6 @@ export const ABSOL: Pokemon = {
   skillPercentage: 3.8,
   berry: WIKI,
   carrySize: 18,
-  maxCarrySize: 18,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: SOOTHING_CACAO },
@@ -586,7 +554,6 @@ export const MIME_JR: Pokemon = {
   ingredientPercentage: 20.1,
   skillPercentage: 3.2,
   carrySize: 7,
-  maxCarrySize: 7,
 };
 
 export const CROAGUNK: Pokemon = {
@@ -597,7 +564,6 @@ export const CROAGUNK: Pokemon = {
   skillPercentage: 4.2,
   berry: CHESTO,
   carrySize: 10,
-  maxCarrySize: 10,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 2, ingredient: PURE_OIL },
@@ -619,7 +585,6 @@ export const TOXICROAK: Pokemon = {
   ingredientPercentage: 22.9,
   skillPercentage: 4.3,
   carrySize: 14,
-  maxCarrySize: 19,
 };
 
 export const SNOVER: Pokemon = {
@@ -630,7 +595,6 @@ export const SNOVER: Pokemon = {
   skillPercentage: 4.4,
   berry: RAWST,
   carrySize: 10,
-  maxCarrySize: 10,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 2, ingredient: SNOOZY_TOMATO },
@@ -653,7 +617,6 @@ export const ABOMASNOW: Pokemon = {
   ingredientPercentage: 25.0,
   skillPercentage: 4.4,
   carrySize: 21,
-  maxCarrySize: 26,
 };
 
 export const STUFFUL: Pokemon = {
@@ -664,7 +627,6 @@ export const STUFFUL: Pokemon = {
   skillPercentage: 1.1,
   berry: CHERI,
   carrySize: 13,
-  maxCarrySize: 13,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 2, ingredient: GREENGRASS_CORN },
@@ -687,7 +649,6 @@ export const BEWEAR: Pokemon = {
   ingredientPercentage: 22.9,
   skillPercentage: 1.3,
   carrySize: 20,
-  maxCarrySize: 25,
 };
 
 export const COMFEY: Pokemon = {
@@ -698,7 +659,6 @@ export const COMFEY: Pokemon = {
   skillPercentage: 2.2,
   berry: PECHA,
   carrySize: 20,
-  maxCarrySize: 20,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: GREENGRASS_CORN },
@@ -722,7 +682,6 @@ export const CRAMORANT: Pokemon = {
   skillPercentage: 3.3,
   berry: PAMTRE,
   carrySize: 19,
-  maxCarrySize: 19,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 2, ingredient: PURE_OIL },
@@ -746,7 +705,6 @@ export const SPRIGATITO: Pokemon = {
   skillPercentage: 2.3,
   berry: DURIN,
   carrySize: 10,
-  maxCarrySize: 10,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: SOFT_POTATO },
@@ -769,7 +727,6 @@ export const FLORAGATO: Pokemon = {
   ingredientPercentage: 20.9,
   skillPercentage: 2.3,
   carrySize: 14,
-  maxCarrySize: 19,
 };
 
 export const MEOWSCARADA: Pokemon = {
@@ -780,7 +737,6 @@ export const MEOWSCARADA: Pokemon = {
   skillPercentage: 2.2,
   berry: WIKI,
   carrySize: 18,
-  maxCarrySize: 28,
 };
 
 export const FUECOCO: Pokemon = {
@@ -791,7 +747,6 @@ export const FUECOCO: Pokemon = {
   skillPercentage: 5.3,
   berry: LEPPA,
   carrySize: 11,
-  maxCarrySize: 11,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: FANCY_APPLE },
@@ -814,7 +769,6 @@ export const CROCALOR: Pokemon = {
   ingredientPercentage: 24.7,
   skillPercentage: 5,
   carrySize: 16,
-  maxCarrySize: 21,
 };
 
 export const SKELEDIRGE: Pokemon = {
@@ -825,7 +779,6 @@ export const SKELEDIRGE: Pokemon = {
   skillPercentage: 6.2,
   berry: BLUK,
   carrySize: 19,
-  maxCarrySize: 29,
 };
 
 export const QUAXLY: Pokemon = {
@@ -836,7 +789,6 @@ export const QUAXLY: Pokemon = {
   skillPercentage: 2.8,
   berry: ORAN,
   carrySize: 10,
-  maxCarrySize: 10,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 2, ingredient: GREENGRASS_SOYBEANS },
@@ -859,7 +811,6 @@ export const QUAXWELL: Pokemon = {
   ingredientPercentage: 25.9,
   skillPercentage: 2.7,
   carrySize: 14,
-  maxCarrySize: 19,
 };
 
 export const QUAQUAVAL: Pokemon = {
@@ -870,7 +821,6 @@ export const QUAQUAVAL: Pokemon = {
   skillPercentage: 2.4,
   berry: CHERI,
   carrySize: 19,
-  maxCarrySize: 29,
 };
 
 export const OPTIMAL_INGREDIENT_SPECIALISTS: Pokemon[] = [

--- a/common/src/domain/pokemon/pokemon.test.ts
+++ b/common/src/domain/pokemon/pokemon.test.ts
@@ -14,3 +14,25 @@ describe('remainingEvolutions', () => {
     });
   });
 });
+
+describe('previousEvolutions', () => {
+  it('shall never be negative', () => {
+    COMPLETE_POKEDEX.forEach((pokemon: Pokemon) => {
+      expect(pokemon.previousEvolutions).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  it('shall not exceed 2', () => {
+    COMPLETE_POKEDEX.forEach((pokemon: Pokemon) => {
+      expect(pokemon.previousEvolutions).toBeLessThanOrEqual(2);
+    });
+  });
+});
+
+describe('maxCarrySize', () => {
+  it('shall match computed max', () => {
+    COMPLETE_POKEDEX.forEach((pokemon: Pokemon) => {
+      expect(pokemon.maxCarrySize).toEqual(pokemon.carrySize + 5 * pokemon.previousEvolutions);
+    });
+  });
+});

--- a/common/src/domain/pokemon/pokemon.test.ts
+++ b/common/src/domain/pokemon/pokemon.test.ts
@@ -28,11 +28,3 @@ describe('previousEvolutions', () => {
     });
   });
 });
-
-describe('maxCarrySize', () => {
-  it('shall match computed max', () => {
-    COMPLETE_POKEDEX.forEach((pokemon: Pokemon) => {
-      expect(pokemon.maxCarrySize).toEqual(pokemon.carrySize + 5 * pokemon.previousEvolutions);
-    });
-  });
-});

--- a/common/src/domain/pokemon/pokemon.ts
+++ b/common/src/domain/pokemon/pokemon.ts
@@ -22,7 +22,6 @@ export interface Pokemon {
   skillPercentage: number;
   berry: Berry;
   carrySize: number;
-  maxCarrySize: number;
   previousEvolutions: number;
   remainingEvolutions: number;
   ingredient0: IngredientSet;
@@ -39,7 +38,6 @@ export const MOCK_POKEMON: Pokemon = {
   skillPercentage: 0,
   berry: BELUE,
   carrySize: 0,
-  maxCarrySize: 0,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 0, ingredient: SLOWPOKE_TAIL },

--- a/common/src/domain/pokemon/pokemon.ts
+++ b/common/src/domain/pokemon/pokemon.ts
@@ -23,6 +23,7 @@ export interface Pokemon {
   berry: Berry;
   carrySize: number;
   maxCarrySize: number;
+  previousEvolutions: number;
   remainingEvolutions: number;
   ingredient0: IngredientSet;
   ingredient30: IngredientSet[];
@@ -39,6 +40,7 @@ export const MOCK_POKEMON: Pokemon = {
   berry: BELUE,
   carrySize: 0,
   maxCarrySize: 0,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 0, ingredient: SLOWPOKE_TAIL },
   ingredient30: [{ amount: 0, ingredient: SLOWPOKE_TAIL }],

--- a/common/src/domain/pokemon/skill-pokemon.ts
+++ b/common/src/domain/pokemon/skill-pokemon.ts
@@ -60,6 +60,7 @@ export const PIKACHU_CHRISTMAS: Pokemon = {
   berry: GREPA,
   carrySize: 16,
   maxCarrySize: 16,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
   ingredient30: [
@@ -83,6 +84,7 @@ export const JIGGLYPUFF: Pokemon = {
   berry: PECHA,
   carrySize: 9,
   maxCarrySize: 14,
+  previousEvolutions: 1,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: HONEY },
   ingredient30: [
@@ -116,6 +118,7 @@ export const MEOWTH: Pokemon = {
   berry: PERSIM,
   carrySize: 9,
   maxCarrySize: 9,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: MOOMOO_MILK },
   ingredient30: [
@@ -148,6 +151,7 @@ export const PSYDUCK: Pokemon = {
   berry: ORAN,
   carrySize: 8,
   maxCarrySize: 8,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: SOOTHING_CACAO },
   ingredient30: [
@@ -181,6 +185,7 @@ export const GROWLITHE: Pokemon = {
   berry: LEPPA,
   carrySize: 8,
   maxCarrySize: 8,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: FIERY_HERB },
   ingredient30: [
@@ -214,6 +219,7 @@ export const SLOWPOKE: Pokemon = {
   berry: ORAN,
   carrySize: 9,
   maxCarrySize: 9,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: SOOTHING_CACAO },
   ingredient30: [
@@ -247,6 +253,7 @@ export const MAGNEMITE: Pokemon = {
   berry: BELUE,
   carrySize: 8,
   maxCarrySize: 8,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: PURE_OIL },
   ingredient30: [
@@ -279,6 +286,7 @@ export const EEVEE: Pokemon = {
   berry: PERSIM,
   carrySize: 12,
   maxCarrySize: 12,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: MOOMOO_MILK },
   ingredient30: [
@@ -348,6 +356,7 @@ export const TOGEPI: Pokemon = {
   berry: PECHA,
   carrySize: 8,
   maxCarrySize: 8,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: FANCY_EGG },
   ingredient30: [
@@ -381,6 +390,7 @@ export const MAREEP: Pokemon = {
   berry: GREPA,
   carrySize: 9,
   maxCarrySize: 9,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: FIERY_HERB },
   ingredient30: [
@@ -423,6 +433,7 @@ export const SUDOWOODO: Pokemon = {
   berry: SITRUS,
   carrySize: 16,
   maxCarrySize: 21,
+  previousEvolutions: 1,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: SNOOZY_TOMATO },
   ingredient30: [
@@ -480,6 +491,7 @@ export const WOBBUFFET: Pokemon = {
   berry: MAGO,
   carrySize: 13,
   maxCarrySize: 18,
+  previousEvolutions: 1,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
   ingredient30: [
@@ -503,6 +515,7 @@ export const HERACROSS: Pokemon = {
   berry: LUM,
   carrySize: 20,
   maxCarrySize: 20,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: HONEY },
   ingredient30: [
@@ -526,6 +539,7 @@ export const RAIKOU: Pokemon = {
   berry: GREPA,
   carrySize: 22,
   maxCarrySize: 22,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: BEAN_SAUSAGE },
   ingredient30: [
@@ -549,6 +563,7 @@ export const ENTEI: Pokemon = {
   berry: LEPPA,
   carrySize: 19,
   maxCarrySize: 19,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: PURE_OIL },
   ingredient30: [
@@ -572,6 +587,7 @@ export const RALTS: Pokemon = {
   berry: MAGO,
   carrySize: 9,
   maxCarrySize: 9,
+  previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
   ingredient30: [
@@ -615,6 +631,7 @@ export const SABLEYE: Pokemon = {
   berry: WIKI,
   carrySize: 16,
   maxCarrySize: 16,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: PURE_OIL },
   ingredient30: [
@@ -638,6 +655,7 @@ export const GULPIN: Pokemon = {
   berry: CHESTO,
   carrySize: 8,
   maxCarrySize: 8,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: GREENGRASS_SOYBEANS },
   ingredient30: [
@@ -691,6 +709,7 @@ export const RIOLU: Pokemon = {
   berry: CHERI,
   carrySize: 9,
   maxCarrySize: 9,
+  previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: PURE_OIL },
   ingredient30: [
@@ -792,6 +811,7 @@ export const DEDENNE: Pokemon = {
   berry: GREPA,
   carrySize: 19,
   maxCarrySize: 19,
+  previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
   ingredient30: [

--- a/common/src/domain/pokemon/skill-pokemon.ts
+++ b/common/src/domain/pokemon/skill-pokemon.ts
@@ -59,7 +59,6 @@ export const PIKACHU_CHRISTMAS: Pokemon = {
   skillPercentage: 4.2,
   berry: GREPA,
   carrySize: 16,
-  maxCarrySize: 16,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
@@ -83,7 +82,6 @@ export const JIGGLYPUFF: Pokemon = {
   skillPercentage: 4.3,
   berry: PECHA,
   carrySize: 9,
-  maxCarrySize: 14,
   previousEvolutions: 1,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: HONEY },
@@ -106,7 +104,6 @@ export const WIGGLYTUFF: Pokemon = {
   ingredientPercentage: 17.4,
   skillPercentage: 4.0,
   carrySize: 13,
-  maxCarrySize: 23,
 };
 
 export const MEOWTH: Pokemon = {
@@ -117,7 +114,6 @@ export const MEOWTH: Pokemon = {
   skillPercentage: 4.2,
   berry: PERSIM,
   carrySize: 9,
-  maxCarrySize: 9,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: MOOMOO_MILK },
@@ -139,7 +135,6 @@ export const PERSIAN: Pokemon = {
   ingredientPercentage: 16.9,
   skillPercentage: 4.4,
   carrySize: 12,
-  maxCarrySize: 17,
 };
 
 export const PSYDUCK: Pokemon = {
@@ -150,7 +145,6 @@ export const PSYDUCK: Pokemon = {
   skillPercentage: 12.6,
   berry: ORAN,
   carrySize: 8,
-  maxCarrySize: 8,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: SOOTHING_CACAO },
@@ -173,7 +167,6 @@ export const GOLDUCK: Pokemon = {
   ingredientPercentage: 16.2,
   skillPercentage: 12.5,
   carrySize: 14,
-  maxCarrySize: 19,
 };
 
 export const GROWLITHE: Pokemon = {
@@ -184,7 +177,6 @@ export const GROWLITHE: Pokemon = {
   skillPercentage: 5.0,
   berry: LEPPA,
   carrySize: 8,
-  maxCarrySize: 8,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: FIERY_HERB },
@@ -207,7 +199,6 @@ export const ARCANINE: Pokemon = {
   ingredientPercentage: 13.6,
   skillPercentage: 4.9,
   carrySize: 16,
-  maxCarrySize: 21,
 };
 
 export const SLOWPOKE: Pokemon = {
@@ -218,7 +209,6 @@ export const SLOWPOKE: Pokemon = {
   skillPercentage: 6.7,
   berry: ORAN,
   carrySize: 9,
-  maxCarrySize: 9,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: SOOTHING_CACAO },
@@ -241,7 +231,6 @@ export const SLOWBRO: Pokemon = {
   ingredientPercentage: 19.7,
   skillPercentage: 6.8,
   carrySize: 16,
-  maxCarrySize: 21,
 };
 
 export const MAGNEMITE: Pokemon = {
@@ -252,7 +241,6 @@ export const MAGNEMITE: Pokemon = {
   skillPercentage: 6.4,
   berry: BELUE,
   carrySize: 8,
-  maxCarrySize: 8,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: PURE_OIL },
@@ -274,7 +262,6 @@ export const MAGNETON: Pokemon = {
   ingredientPercentage: 18.2,
   skillPercentage: 6.3,
   carrySize: 11,
-  maxCarrySize: 16,
 };
 
 export const EEVEE: Pokemon = {
@@ -285,7 +272,6 @@ export const EEVEE: Pokemon = {
   skillPercentage: 5.5,
   berry: PERSIM,
   carrySize: 12,
-  maxCarrySize: 12,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: MOOMOO_MILK },
@@ -309,7 +295,6 @@ export const VAPOREON: Pokemon = {
   skillPercentage: 6.1,
   berry: ORAN,
   carrySize: 13,
-  maxCarrySize: 18,
   skill: INGREDIENT_MAGNET_S,
 };
 
@@ -321,7 +306,6 @@ export const JOLTEON: Pokemon = {
   skillPercentage: 3.9,
   berry: GREPA,
   carrySize: 17,
-  maxCarrySize: 22,
   skill: EXTRA_HELPFUL_S,
 };
 
@@ -333,7 +317,6 @@ export const FLAREON: Pokemon = {
   skillPercentage: 5.2,
   berry: LEPPA,
   carrySize: 14,
-  maxCarrySize: 19,
   skill: COOKING_POWER_UP_S,
 };
 
@@ -344,7 +327,6 @@ export const IGGLYBUFF: Pokemon = {
   ingredientPercentage: 17.0,
   skillPercentage: 3.8,
   carrySize: 8,
-  maxCarrySize: 8,
 };
 
 export const TOGEPI: Pokemon = {
@@ -355,7 +337,6 @@ export const TOGEPI: Pokemon = {
   skillPercentage: 4.9,
   berry: PECHA,
   carrySize: 8,
-  maxCarrySize: 8,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: FANCY_EGG },
@@ -378,7 +359,6 @@ export const TOGETIC: Pokemon = {
   ingredientPercentage: 16.3,
   skillPercentage: 5.6,
   carrySize: 10,
-  maxCarrySize: 15,
 };
 
 export const MAREEP: Pokemon = {
@@ -389,7 +369,6 @@ export const MAREEP: Pokemon = {
   skillPercentage: 4.7,
   berry: GREPA,
   carrySize: 9,
-  maxCarrySize: 9,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: FIERY_HERB },
@@ -411,7 +390,6 @@ export const FLAAFFY: Pokemon = {
   ingredientPercentage: 12.7,
   skillPercentage: 4.6,
   carrySize: 11,
-  maxCarrySize: 16,
 };
 
 export const AMPHAROS: Pokemon = {
@@ -421,7 +399,6 @@ export const AMPHAROS: Pokemon = {
   ingredientPercentage: 13.0,
   skillPercentage: 4.7,
   carrySize: 15,
-  maxCarrySize: 25,
 };
 
 export const SUDOWOODO: Pokemon = {
@@ -432,7 +409,6 @@ export const SUDOWOODO: Pokemon = {
   skillPercentage: 7.2,
   berry: SITRUS,
   carrySize: 16,
-  maxCarrySize: 21,
   previousEvolutions: 1,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: SNOOZY_TOMATO },
@@ -456,7 +432,6 @@ export const ESPEON: Pokemon = {
   skillPercentage: 4.4,
   berry: MAGO,
   carrySize: 16,
-  maxCarrySize: 21,
   skill: CHARGE_STRENGTH_M,
 };
 
@@ -468,7 +443,6 @@ export const UMBREON: Pokemon = {
   skillPercentage: 14.1,
   berry: WIKI,
   carrySize: 14,
-  maxCarrySize: 19,
   skill: CHARGE_ENERGY_S,
 };
 
@@ -479,7 +453,6 @@ export const SLOWKING: Pokemon = {
   ingredientPercentage: 16.6,
   skillPercentage: 7.4,
   carrySize: 17,
-  maxCarrySize: 22,
 };
 
 export const WOBBUFFET: Pokemon = {
@@ -490,7 +463,6 @@ export const WOBBUFFET: Pokemon = {
   skillPercentage: 6.4,
   berry: MAGO,
   carrySize: 13,
-  maxCarrySize: 18,
   previousEvolutions: 1,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
@@ -514,7 +486,6 @@ export const HERACROSS: Pokemon = {
   skillPercentage: 4.7,
   berry: LUM,
   carrySize: 20,
-  maxCarrySize: 20,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: HONEY },
@@ -538,7 +509,6 @@ export const RAIKOU: Pokemon = {
   skillPercentage: 1.9,
   berry: GREPA,
   carrySize: 22,
-  maxCarrySize: 22,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: BEAN_SAUSAGE },
@@ -562,7 +532,6 @@ export const ENTEI: Pokemon = {
   skillPercentage: 2.3,
   berry: LEPPA,
   carrySize: 19,
-  maxCarrySize: 19,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: PURE_OIL },
@@ -586,7 +555,6 @@ export const RALTS: Pokemon = {
   skillPercentage: 4.3,
   berry: MAGO,
   carrySize: 9,
-  maxCarrySize: 9,
   previousEvolutions: 0,
   remainingEvolutions: 2,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },
@@ -609,7 +577,6 @@ export const KIRLIA: Pokemon = {
   ingredientPercentage: 14.6,
   skillPercentage: 4.3,
   carrySize: 13,
-  maxCarrySize: 18,
 };
 
 export const GARDEVOIR: Pokemon = {
@@ -619,7 +586,6 @@ export const GARDEVOIR: Pokemon = {
   ingredientPercentage: 14.4,
   skillPercentage: 4.2,
   carrySize: 18,
-  maxCarrySize: 28,
 };
 
 export const SABLEYE: Pokemon = {
@@ -630,7 +596,6 @@ export const SABLEYE: Pokemon = {
   skillPercentage: 6.8,
   berry: WIKI,
   carrySize: 16,
-  maxCarrySize: 16,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: PURE_OIL },
@@ -654,7 +619,6 @@ export const GULPIN: Pokemon = {
   skillPercentage: 6.3,
   berry: CHESTO,
   carrySize: 8,
-  maxCarrySize: 8,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: GREENGRASS_SOYBEANS },
@@ -677,7 +641,6 @@ export const SWALOT: Pokemon = {
   ingredientPercentage: 21,
   skillPercentage: 7,
   carrySize: 19,
-  maxCarrySize: 24,
 };
 
 export const WYNAUT: Pokemon = {
@@ -687,7 +650,6 @@ export const WYNAUT: Pokemon = {
   ingredientPercentage: 21.3,
   skillPercentage: 5.9,
   carrySize: 7,
-  maxCarrySize: 7,
 };
 
 export const BONSLY: Pokemon = {
@@ -697,7 +659,6 @@ export const BONSLY: Pokemon = {
   ingredientPercentage: 18.9,
   skillPercentage: 6.1,
   carrySize: 8,
-  maxCarrySize: 8,
 };
 
 export const RIOLU: Pokemon = {
@@ -708,7 +669,6 @@ export const RIOLU: Pokemon = {
   skillPercentage: 3.8,
   berry: CHERI,
   carrySize: 9,
-  maxCarrySize: 9,
   previousEvolutions: 0,
   remainingEvolutions: 1,
   ingredient0: { amount: 1, ingredient: PURE_OIL },
@@ -731,7 +691,6 @@ export const LUCARIO: Pokemon = {
   ingredientPercentage: 15.0,
   skillPercentage: 5.1,
   carrySize: 14,
-  maxCarrySize: 19,
 };
 
 export const MAGNEZONE: Pokemon = {
@@ -741,7 +700,6 @@ export const MAGNEZONE: Pokemon = {
   ingredientPercentage: 17.9,
   skillPercentage: 6.2,
   carrySize: 13,
-  maxCarrySize: 23,
 };
 
 export const TOGEKISS: Pokemon = {
@@ -751,7 +709,6 @@ export const TOGEKISS: Pokemon = {
   ingredientPercentage: 15.8,
   skillPercentage: 5.3,
   carrySize: 16,
-  maxCarrySize: 26,
 };
 
 export const LEAFEON: Pokemon = {
@@ -762,7 +719,6 @@ export const LEAFEON: Pokemon = {
   skillPercentage: 5.9,
   berry: DURIN,
   carrySize: 13,
-  maxCarrySize: 18,
   skill: ENERGIZING_CHEER_S,
 };
 
@@ -774,7 +730,6 @@ export const GLACEON: Pokemon = {
   skillPercentage: 6.3,
   berry: RAWST,
   carrySize: 12,
-  maxCarrySize: 17,
   skill: COOKING_POWER_UP_S,
 };
 
@@ -785,7 +740,6 @@ export const GALLADE: Pokemon = {
   ingredientPercentage: 14.7,
   skillPercentage: 5.4,
   carrySize: 19,
-  maxCarrySize: 29,
   berry: CHERI,
   skill: EXTRA_HELPFUL_S,
 };
@@ -798,7 +752,6 @@ export const SYLVEON: Pokemon = {
   skillPercentage: 4.0,
   berry: PECHA,
   carrySize: 15,
-  maxCarrySize: 20,
   skill: ENERGY_FOR_EVERYONE,
 };
 
@@ -810,7 +763,6 @@ export const DEDENNE: Pokemon = {
   skillPercentage: 4.5,
   berry: GREPA,
   carrySize: 19,
-  maxCarrySize: 19,
   previousEvolutions: 0,
   remainingEvolutions: 0,
   ingredient0: { amount: 1, ingredient: FANCY_APPLE },

--- a/common/src/utils/pokemon-utils/evolution-utils.test.ts
+++ b/common/src/utils/pokemon-utils/evolution-utils.test.ts
@@ -13,7 +13,6 @@ const MOCK_POKEMON: Pokemon = {
   skillPercentage: 0,
   berry: BELUE,
   carrySize: 0,
-  maxCarrySize: 5,
   previousEvolutions: 1,
   remainingEvolutions: 1,
   ingredient0: { amount: 0, ingredient: SLOWPOKE_TAIL },

--- a/common/src/utils/pokemon-utils/evolution-utils.test.ts
+++ b/common/src/utils/pokemon-utils/evolution-utils.test.ts
@@ -14,6 +14,7 @@ const MOCK_POKEMON: Pokemon = {
   berry: BELUE,
   carrySize: 0,
   maxCarrySize: 5,
+  previousEvolutions: 1,
   remainingEvolutions: 1,
   ingredient0: { amount: 0, ingredient: SLOWPOKE_TAIL },
   ingredient30: [{ amount: 0, ingredient: SLOWPOKE_TAIL }],
@@ -25,10 +26,18 @@ describe('evolvesFrom', () => {
   it('shall have 1 fewer remaining evolution', () => {
     expect(evolvesFrom(MOCK_POKEMON).remainingEvolutions).toBe(0);
   });
+
+  it('shall have 1 more previous evolution', () => {
+    expect(evolvesFrom(MOCK_POKEMON).previousEvolutions).toBe(2);
+  });
 });
 
 describe('evolvesInto', () => {
   it('shall have 1 more remaining evolution', () => {
     expect(evolvesInto(MOCK_POKEMON).remainingEvolutions).toBe(2);
+  });
+
+  it('shall have 1 fewer previous evolution', () => {
+    expect(evolvesInto(MOCK_POKEMON).previousEvolutions).toBe(0);
   });
 });

--- a/common/src/utils/pokemon-utils/evolution-utils.ts
+++ b/common/src/utils/pokemon-utils/evolution-utils.ts
@@ -3,6 +3,7 @@ import { Pokemon } from '../../domain/pokemon';
 export function evolvesFrom(previousForm: Pokemon): Pokemon {
   return {
     ...previousForm,
+    previousEvolutions: previousForm.previousEvolutions + 1,
     remainingEvolutions: previousForm.remainingEvolutions - 1,
   };
 }
@@ -10,6 +11,7 @@ export function evolvesFrom(previousForm: Pokemon): Pokemon {
 export function evolvesInto(nextForm: Pokemon): Pokemon {
   return {
     ...nextForm,
+    previousEvolutions: nextForm.previousEvolutions - 1,
     remainingEvolutions: nextForm.remainingEvolutions + 1,
   };
 }

--- a/common/src/utils/pokemon-utils/pokemon-utils.test.ts
+++ b/common/src/utils/pokemon-utils/pokemon-utils.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from 'vitest';
-import { PINSIR } from '../../domain/pokemon';
-import { getPokemon } from './pokemon-utils';
+import { BELUE } from '../../domain/berry';
+import { SLOWPOKE_TAIL } from '../../domain/ingredient';
+import { HELPER_BOOST } from '../../domain/mainskill';
+import { PINSIR, Pokemon } from '../../domain/pokemon';
+import { getPokemon, maxCarrySize } from './pokemon-utils';
+
+const MOCK_POKEMON: Pokemon = {
+  name: 'Mockemon',
+  specialty: 'berry',
+  frequency: 0,
+  ingredientPercentage: 0,
+  skillPercentage: 0,
+  berry: BELUE,
+  carrySize: 0,
+  previousEvolutions: 1,
+  remainingEvolutions: 1,
+  ingredient0: { amount: 0, ingredient: SLOWPOKE_TAIL },
+  ingredient30: [{ amount: 0, ingredient: SLOWPOKE_TAIL }],
+  ingredient60: [{ amount: 0, ingredient: SLOWPOKE_TAIL }],
+  skill: HELPER_BOOST,
+};
 
 describe('getPokemon', () => {
   it('shall return PINSIR for pinSIr name', () => {
@@ -9,5 +28,11 @@ describe('getPokemon', () => {
 
   it("shall throw if Pokémon can't be found", () => {
     expect(() => getPokemon('missing')).toThrow(Error);
+  });
+});
+
+describe('maxCarrySize', () => {
+  it('shall return 5 for MOCK_POKEMON', () => {
+    expect(maxCarrySize(MOCK_POKEMON)).toBe(5);
   });
 });

--- a/common/src/utils/pokemon-utils/pokemon-utils.ts
+++ b/common/src/utils/pokemon-utils/pokemon-utils.ts
@@ -7,3 +7,7 @@ export function getPokemon(name: string): Pokemon {
   }
   return pkmn;
 }
+
+export function maxCarrySize(pokemon: Pokemon): number {
+  return pokemon.carrySize + 5 * pokemon.previousEvolutions;
+}

--- a/frontend/src/components/calculator/pokemon-input/carry-size-button.test.ts
+++ b/frontend/src/components/calculator/pokemon-input/carry-size-button.test.ts
@@ -1,7 +1,7 @@
 import CarrySizeButton from '@/components/calculator/pokemon-input/carry-size-button.vue'
 import { mount, VueWrapper } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
-import { pokemon, type PokemonInstanceExt } from 'sleepapi-common'
+import { maxCarrySize, pokemon, type PokemonInstanceExt } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 describe('CarrySizeButton', () => {
@@ -42,7 +42,7 @@ describe('CarrySizeButton', () => {
   it('displays carry size options correctly in the list', async () => {
     await wrapper.setData({ menu: true })
     const listItems = wrapper.findAllComponents({ name: 'v-list-item' })
-    const expectedValues = [pokemon.PIKACHU.carrySize, pokemon.PIKACHU.maxCarrySize]
+    const expectedValues = [pokemon.PIKACHU.carrySize, maxCarrySize(pokemon.PIKACHU)]
     listItems.forEach((item, index) => {
       expect(item.text()).toBe(expectedValues[index].toString())
     })
@@ -68,7 +68,7 @@ describe('CarrySizeButton', () => {
 
   it('updates carry limit when the pokemon prop changes', async () => {
     const newPokemon = {
-      pokemon: { name: 'Bulbasaur', carrySize: 5, maxCarrySize: 15 },
+      pokemon: { name: 'Bulbasaur', carrySize: 5, previousEvolutions: 2 },
       carrySize: 10
     } as PokemonInstanceExt
     await wrapper.setProps({ pokemonInstance: newPokemon })

--- a/frontend/src/components/calculator/pokemon-input/carry-size-button.vue
+++ b/frontend/src/components/calculator/pokemon-input/carry-size-button.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts">
-import { pokemon, type PokemonInstanceExt } from 'sleepapi-common'
+import { maxCarrySize, pokemon, type PokemonInstanceExt } from 'sleepapi-common'
 import type { PropType } from 'vue'
 
 export default {
@@ -34,20 +34,17 @@ export default {
   }),
   computed: {
     carrySizeOptions() {
-      const { carrySize, maxCarrySize } = this.pokemonInstance.pokemon
+      const { carrySize, previousEvolutions } = this.pokemonInstance.pokemon
       const values = [carrySize]
 
-      if (maxCarrySize > carrySize) {
-        values.push(carrySize + 5)
-        if (maxCarrySize === carrySize + 10) {
-          values.push(maxCarrySize)
-        }
+      for (let i = 1; i <= previousEvolutions; ++i) {
+        values.push(carrySize + i * 5)
       }
 
       return values
     },
     singleStageMon() {
-      return this.pokemonInstance.pokemon.carrySize === this.pokemonInstance.pokemon.maxCarrySize
+      return this.pokemonInstance.pokemon.previousEvolutions === 0
     },
     pokemon() {
       return this.pokemonInstance.pokemon
@@ -62,7 +59,7 @@ export default {
 
         const newCarrySize = loadFromExisting
           ? this.pokemonInstance.carrySize
-          : newPokemon.maxCarrySize
+          : maxCarrySize(newPokemon)
         this.$emit('update-carry', newCarrySize)
       }
     }

--- a/frontend/src/components/calculator/pokemon-input/mainskill-button.vue
+++ b/frontend/src/components/calculator/pokemon-input/mainskill-button.vue
@@ -90,7 +90,7 @@ export default {
         if (this.pokemonInstance.skillLevel > 0) {
           this.mainskillLevel = this.pokemonInstance.skillLevel
         } else {
-          const nrOfEvolutions = (newPokemon.maxCarrySize - newPokemon.carrySize) / 5
+          const nrOfEvolutions = newPokemon.previousEvolutions
           this.mainskillLevel = 1 + nrOfEvolutions
         }
         this.$emit('update-skill-level', this.mainskillLevel)

--- a/frontend/src/components/calculator/pokemon-input/pokemon-input.test.ts
+++ b/frontend/src/components/calculator/pokemon-input/pokemon-input.test.ts
@@ -6,6 +6,7 @@ import { VueWrapper, mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import {
   ingredient,
+  maxCarrySize,
   nature,
   pokemon,
   subskill,
@@ -108,7 +109,7 @@ describe('PokemonInput', () => {
     expect(updatedPokemonInstance.pokemon).not.toEqual(pokemon.MOCK_POKEMON)
 
     expect(updatedPokemonInstance.pokemon).toEqual(pokemon.GALLADE)
-    expect(updatedPokemonInstance.carrySize).toBe(pokemon.GALLADE.maxCarrySize)
+    expect(updatedPokemonInstance.carrySize).toBe(maxCarrySize(pokemon.GALLADE))
   })
 
   it('renders child components correctly', () => {

--- a/frontend/src/components/calculator/pokemon-input/pokemon-input.vue
+++ b/frontend/src/components/calculator/pokemon-input/pokemon-input.vue
@@ -154,6 +154,7 @@ import { useUserStore } from '@/stores/user-store'
 import {
   RP,
   ingredient,
+  maxCarrySize,
   nature,
   pokemon,
   uuid,
@@ -222,7 +223,7 @@ export default defineComponent({
       this.pokemonInstance = JSON.parse(JSON.stringify(existingPokemon))
     } else if (this.selectedPokemon) {
       this.pokemonInstance.pokemon = this.selectedPokemon
-      this.pokemonInstance.carrySize = this.selectedPokemon.maxCarrySize
+      this.pokemonInstance.carrySize = maxCarrySize(this.selectedPokemon)
       this.pokemonInstance.externalId = uuid.v4()
     } else console.error('Missing both cached and search input mon, contact developer')
 


### PR DESCRIPTION
Goal: remove `maxCarrySize` from each Pokemon's data

Why: make it easier and less error-prone to add new Pokemon

This PR has 3 commits. The first adds a `previousEvolutions` field, similar to `remainingEvolutions` added in #358. The second adds tests. Because `maxCarrySize` is still present when I add the tests, I included a test to verify that the data match. The final (largest) commit removes `maxCarrySize` and updates all the files in backend and frontend that used to use it.