### PR TITLE
fix: calculator and compare tools keep correct size

### DIFF
--- a/frontend/src/components/calculator/team-slot.vue
+++ b/frontend/src/components/calculator/team-slot.vue
@@ -104,7 +104,7 @@
           </v-row>
         </v-row>
         <v-col cols="6">
-          <v-img :src="imageUrl" />
+          <v-img :src="imageUrl" style="aspect-ratio: 1 / 1" />
           <v-card
             v-if="isLeader && teamStore.tab !== 'members'"
             class="text-center leader-card"

--- a/frontend/src/components/service-worker/service-worker-update.test.ts
+++ b/frontend/src/components/service-worker/service-worker-update.test.ts
@@ -1,0 +1,68 @@
+import { VueWrapper, flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+import { useVersionStore } from '@/stores/version-store/version-store'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import ServiceWorkerUpdate from './service-worker-update.vue'
+
+const MOCK_APP_VERSION = '2.0.0'
+
+describe('Service worker update', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ServiceWorkerUpdate>>
+  let versionStore: ReturnType<typeof useVersionStore>
+
+  beforeEach(() => {
+    vi.stubGlobal('APP_VERSION', MOCK_APP_VERSION)
+    setActivePinia(createPinia())
+    versionStore = useVersionStore()
+    wrapper = mount(ServiceWorkerUpdate)
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          onupdatefound: null
+        })
+      },
+      writable: true
+    })
+  })
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount()
+    }
+  })
+
+  it('does not show banner if update is not found', async () => {
+    wrapper.vm.updateFound = true
+    await nextTick()
+    expect(wrapper.find('v-banner').exists()).toBe(false)
+  })
+
+  it('shows banner when service worker update is found', async () => {
+    wrapper.vm.updateFound = true
+    await nextTick()
+
+    expect(wrapper.find('.v-banner').exists()).toBe(true)
+  })
+
+  it('updates version if updateFound is true on mount', async () => {
+    versionStore.version = '1.0.0'
+    versionStore.updateVersion = vi.fn()
+    mount(ServiceWorkerUpdate)
+    await flushPromises()
+
+    expect(versionStore.updateVersion).toHaveBeenCalled()
+  })
+
+  it('logs debug message when client cache is up to date', async () => {
+    const consoleDebugSpy = vi.spyOn(console, 'debug')
+    mount(ServiceWorkerUpdate)
+    await flushPromises()
+
+    expect(consoleDebugSpy).toHaveBeenCalledWith(
+      `Client cache up to date with version ${versionStore.version}`
+    )
+  })
+})

--- a/frontend/src/components/service-worker/service-worker-update.vue
+++ b/frontend/src/components/service-worker/service-worker-update.vue
@@ -28,19 +28,17 @@ export default {
         navigator.serviceWorker
           .register(swUrl)
           .then((reg) => {
-            // TODO: here we probably could clean up cached stuff before checking update
-
-            // TODO: test this: if updateFound that means we already have new version
             if (versionStore.updateFound) {
               versionStore.updateVersion()
             } else {
-              console.log("Client thinks we're on latest")
+              console.debug(`Client cache up to date with version ${versionStore.version}`)
             }
 
             reg.onupdatefound = () => {
-              // TODO: test this: if service worker found update and client is still on old code
               if (!versionStore.updateFound) {
-                console.log('SW found update, client not on latest')
+                console.debug(
+                  `Service worker found update, client was on ${versionStore.version}, prompting client to refresh`
+                )
                 showBanner.value = true
               }
             }

--- a/frontend/src/composables/use-random-phrase/use-random-phrase.ts
+++ b/frontend/src/composables/use-random-phrase/use-random-phrase.ts
@@ -7,6 +7,7 @@ export function useRandomPhrase() {
   const fullPhrase = ref<string>('')
   let typingInterval: number | null = null
   let previousPhrase = ''
+  let typingIndex = 0
 
   const getRandomPhrase = (nature: nature.Nature) => {
     const naturePhrases = phrases[nature.name]
@@ -21,28 +22,29 @@ export function useRandomPhrase() {
       fullPhrase.value = newPhrase
     }
     randomPhrase.value = ''
+    typingIndex = 0
     startTypingAnimation()
   }
 
   const startTypingAnimation = () => {
-    let index = 0
-
     if (typingInterval) {
       clearInterval(typingInterval)
+      typingInterval = null
     }
 
     typingInterval = window.setInterval(() => {
-      if (index < fullPhrase.value.length) {
-        randomPhrase.value += fullPhrase.value[index]
-        index++
+      if (typingIndex < fullPhrase.value.length) {
+        randomPhrase.value += fullPhrase.value[typingIndex]
+        typingIndex++
       } else {
         clearInterval(typingInterval!)
+        typingInterval = null
       }
     }, 15)
   }
 
   const handleVisibilityChange = () => {
-    if (!document.hidden && fullPhrase.value) {
+    if (!document.hidden && typingIndex < fullPhrase.value.length) {
       startTypingAnimation()
     }
   }

--- a/frontend/src/pages/compare/comparison-page.test.ts
+++ b/frontend/src/pages/compare/comparison-page.test.ts
@@ -110,7 +110,7 @@ describe('ComparisonPage', () => {
     wrapper.setData({ pokemonToCompare: [] }) // ensures first card is empty
     await nextTick()
 
-    const addCard = wrapper.find('.team-slot .v-card')
+    const addCard = wrapper.find('.compare-slot .v-card')
     expect(addCard.exists()).toBe(true)
 
     await addCard.trigger('click')

--- a/frontend/src/pages/compare/comparison-page.vue
+++ b/frontend/src/pages/compare/comparison-page.vue
@@ -1,11 +1,11 @@
 <template>
-  <v-container class="team-container">
+  <v-container class="comparison-container">
     <v-row dense class="scroll-container" style="flex-wrap: nowrap">
       <!-- Filled compare slot -->
       <v-col
         v-for="(mon, index) in comparisonStore.members"
         :key="index"
-        class="team-slot flex-grow-1"
+        class="compare-slot flex-grow-1"
         style="position: relative; min-width: 18%; max-width: 18%"
       >
         <CompareSlot
@@ -19,7 +19,7 @@
 
       <!-- Click to add new pokemon -->
       <v-col
-        class="team-slot flex-grow-1"
+        class="compare-slot flex-grow-1"
         style="min-width: 20%; max-width: 20%"
         :hidden="comparisonStore.fullTeam"
       >
@@ -239,12 +239,12 @@ export default defineComponent({
   flex: 1;
 }
 
-.team-slot {
+.compare-slot {
   max-height: 25dvh;
   aspect-ratio: 6 / 10;
 }
 
-.team-container {
+.comparison-container {
   max-width: 100%;
 }
 
@@ -254,7 +254,7 @@ export default defineComponent({
 }
 
 @media (min-width: $desktop) {
-  .team-container {
+  .comparison-container {
     max-width: 60dvw;
   }
 }

--- a/frontend/src/stores/version-store/version-store.ts
+++ b/frontend/src/stores/version-store/version-store.ts
@@ -15,7 +15,7 @@ export const useVersionStore = defineStore('version', {
   },
   actions: {
     updateVersion() {
-      console.log(`Client updating version: ${this.version} -> ${APP_VERSION}`)
+      console.debug(`Client updating version: ${this.version} -> ${APP_VERSION}`)
       this.version = APP_VERSION
     }
   },


### PR DESCRIPTION
We had an issue where switching between the calculator and compare pages would transport styling between the pages. This was due to sharing css class names.