### PR TITLE
fix: highlight only current index team slot

### DIFF
--- a/frontend/src/components/calculator/team-slot.vue
+++ b/frontend/src/components/calculator/team-slot.vue
@@ -7,7 +7,9 @@
           :class="[
             'fill-height',
             'rounded-b-0',
-            teamStore.getCurrentMember === pokemonInstance.externalId && teamStore.tab === 'members'
+            teamStore.getCurrentMember === pokemonInstance.externalId &&
+            teamStore.tab === 'members' &&
+            memberIndex === teamStore.getCurrentTeam.memberIndex
               ? 'bg-surface'
               : 'frosted-glass'
           ]"


### PR DESCRIPTION
Previously when adding the same Pokémon twice from Pokébox we would highlight both, since we only checked externalId