### PR TITLE
Sneaky Snacking

### DIFF
--- a/backend/src/controllers/calculator/production.controller.ts
+++ b/backend/src/controllers/calculator/production.controller.ts
@@ -213,7 +213,8 @@ export default class ProductionController {
           nature: getNature(member.nature),
           skillLevel: Math.min(member.skillLevel, pokemon.skill.maxLevel),
           subskills,
-          externalId: member.externalId
+          externalId: member.externalId,
+          sneakySnacking: member.sneakySnacking
         }
       });
     }

--- a/backend/src/controllers/solve/solve.controller.ts
+++ b/backend/src/controllers/solve/solve.controller.ts
@@ -83,7 +83,7 @@ export default class SolveController {
   }
 
   private enrichMemberSettings(settings: TeamMemberSettings): TeamMemberSettingsExt {
-    const { level, carrySize, externalId, ribbon, skillLevel } = settings;
+    const { level, carrySize, externalId, ribbon, skillLevel, sneakySnacking } = settings;
     const subskills = new Set(settings.subskills);
     const nature = getNature(settings.nature);
     return {
@@ -93,7 +93,8 @@ export default class SolveController {
       nature,
       ribbon,
       skillLevel,
-      subskills
+      subskills,
+      sneakySnacking
     };
   }
 

--- a/backend/src/database/dao/team/__snapshots__/team-dao.test.ts.snap
+++ b/backend/src/database/dao/team/__snapshots__/team-dao.test.ts.snap
@@ -38,6 +38,7 @@ exports[`findTeamsWithMembers > shall get team with members 1`] = `
         "saved": true,
         "shiny": false,
         "skillLevel": 5,
+        "sneakySnacking": false,
         "subskills": [
           {
             "level": 10,
@@ -92,6 +93,7 @@ exports[`findTeamsWithMembers > shall get team with members 1`] = `
         "saved": true,
         "shiny": false,
         "skillLevel": 5,
+        "sneakySnacking": false,
         "subskills": [
           {
             "level": 10,
@@ -146,6 +148,7 @@ exports[`findTeamsWithMembers > shall get team with members 1`] = `
         "saved": true,
         "shiny": false,
         "skillLevel": 5,
+        "sneakySnacking": false,
         "subskills": [
           {
             "level": 10,

--- a/backend/src/database/dao/team/team-member/team-member-dao.test.ts
+++ b/backend/src/database/dao/team/team-member/team-member-dao.test.ts
@@ -16,22 +16,24 @@ describe('TeamMemberDAO insert', () => {
     const teamMember = await TeamMemberDAO.insert({
       fk_team_id: 1,
       fk_pokemon_id: 1,
-      member_index: 0
+      member_index: 0,
+      sneaky_snacking: false
     });
     expect(teamMember).toBeDefined();
 
     const data = await TeamMemberDAO.findMultiple();
     expect(data).toMatchInlineSnapshot(`
-[
-  {
-    "fk_pokemon_id": 1,
-    "fk_team_id": 1,
-    "id": 1,
-    "member_index": 0,
-    "version": 1,
-  },
-]
-`);
+      [
+        {
+          "fk_pokemon_id": 1,
+          "fk_team_id": 1,
+          "id": 1,
+          "member_index": 0,
+          "sneaky_snacking": false,
+          "version": 1,
+        },
+      ]
+    `);
   });
 
   it('shall fail to insert entity without fk_team_id', async () => {
@@ -39,7 +41,8 @@ describe('TeamMemberDAO insert', () => {
       TeamMemberDAO.insert({
         fk_team_id: undefined as any,
         fk_pokemon_id: 1,
-        member_index: 0
+        member_index: 0,
+        sneaky_snacking: false
       })
     ).rejects.toThrow(/SQLITE_CONSTRAINT: NOT NULL constraint failed: team_member.fk_team_id/);
   });
@@ -49,7 +52,8 @@ describe('TeamMemberDAO insert', () => {
       TeamMemberDAO.insert({
         fk_team_id: 1,
         fk_pokemon_id: undefined as any,
-        member_index: 0
+        member_index: 0,
+        sneaky_snacking: false
       })
     ).rejects.toThrow(/SQLITE_CONSTRAINT: NOT NULL constraint failed: team_member.fk_pokemon_id/);
   });
@@ -59,7 +63,8 @@ describe('TeamMemberDAO insert', () => {
       TeamMemberDAO.insert({
         fk_team_id: 1,
         fk_pokemon_id: 1,
-        member_index: undefined as any
+        member_index: undefined as any,
+        sneaky_snacking: false
       })
     ).rejects.toThrow(/SQLITE_CONSTRAINT: NOT NULL constraint failed: team_member.member_index/);
   });
@@ -68,13 +73,15 @@ describe('TeamMemberDAO insert', () => {
     await TeamMemberDAO.insert({
       fk_team_id: 1,
       fk_pokemon_id: 1,
-      member_index: 0
+      member_index: 0,
+      sneaky_snacking: false
     });
     await expect(
       TeamMemberDAO.insert({
         fk_team_id: 1,
         fk_pokemon_id: 2,
-        member_index: 0
+        member_index: 0,
+        sneaky_snacking: false
       })
     ).rejects.toThrow(/SQLITE_CONSTRAINT: UNIQUE constraint failed: team_member.fk_team_id, team_member.member_index/);
   });
@@ -85,7 +92,8 @@ describe('TeamMemberDAO update', () => {
     const teamMember = await TeamMemberDAO.insert({
       fk_team_id: 1,
       fk_pokemon_id: 1,
-      member_index: 0
+      member_index: 0,
+      sneaky_snacking: false
     });
     expect(teamMember.fk_pokemon_id).toEqual(1);
 
@@ -93,28 +101,31 @@ describe('TeamMemberDAO update', () => {
 
     const data = await TeamMemberDAO.findMultiple();
     expect(data).toMatchInlineSnapshot(`
-[
-  {
-    "fk_pokemon_id": 2,
-    "fk_team_id": 1,
-    "id": 1,
-    "member_index": 0,
-    "version": 2,
-  },
-]
-`);
+      [
+        {
+          "fk_pokemon_id": 2,
+          "fk_team_id": 1,
+          "id": 1,
+          "member_index": 0,
+          "sneaky_snacking": false,
+          "version": 2,
+        },
+      ]
+    `);
   });
 
   it('shall fail to update entity with duplicate fk_team_id and member_index', async () => {
     await TeamMemberDAO.insert({
       fk_team_id: 1,
       fk_pokemon_id: 1,
-      member_index: 0
+      member_index: 0,
+      sneaky_snacking: false
     });
     const teamMemberB = await TeamMemberDAO.insert({
       fk_team_id: 1,
       fk_pokemon_id: 2,
-      member_index: 1
+      member_index: 1,
+      sneaky_snacking: false
     });
 
     await expect(TeamMemberDAO.update({ ...teamMemberB, member_index: 0 })).rejects.toThrow(
@@ -128,7 +139,8 @@ describe('TeamMemberDAO delete', () => {
     const teamMember = await TeamMemberDAO.insert({
       fk_team_id: 1,
       fk_pokemon_id: 1,
-      member_index: 0
+      member_index: 0,
+      sneaky_snacking: false
     });
 
     await TeamMemberDAO.delete({ id: teamMember.id });

--- a/backend/src/database/dao/team/team-member/team-member-dao.ts
+++ b/backend/src/database/dao/team/team-member/team-member-dao.ts
@@ -7,7 +7,8 @@ const DBTeamMemberSchema = Type.Composite([
   Type.Object({
     fk_team_id: Type.Number(),
     fk_pokemon_id: Type.Number(),
-    member_index: Type.Number()
+    member_index: Type.Number(),
+    sneaky_snacking: Type.Boolean()
   })
 ]);
 export type DBTeamMember = Static<typeof DBTeamMemberSchema>;

--- a/backend/src/database/dao/team/team/__snapshots__/team-dao.test.ts.snap
+++ b/backend/src/database/dao/team/team/__snapshots__/team-dao.test.ts.snap
@@ -38,6 +38,7 @@ exports[`findTeamsWithMembers > shall get team with members 1`] = `
         "saved": true,
         "shiny": false,
         "skillLevel": 5,
+        "sneakySnacking": false,
         "subskills": [
           {
             "level": 10,
@@ -92,6 +93,7 @@ exports[`findTeamsWithMembers > shall get team with members 1`] = `
         "saved": true,
         "shiny": false,
         "skillLevel": 5,
+        "sneakySnacking": false,
         "subskills": [
           {
             "level": 10,
@@ -146,6 +148,7 @@ exports[`findTeamsWithMembers > shall get team with members 1`] = `
         "saved": true,
         "shiny": false,
         "skillLevel": 5,
+        "sneakySnacking": false,
         "subskills": [
           {
             "level": 10,

--- a/backend/src/database/dao/team/team/team-dao.test.ts
+++ b/backend/src/database/dao/team/team/team-dao.test.ts
@@ -331,17 +331,20 @@ describe('findTeamsWithMembers', () => {
     await TeamMemberDAO.insert({
       member_index: 0,
       fk_team_id: 1,
-      fk_pokemon_id: 1
+      fk_pokemon_id: 1,
+      sneaky_snacking: false
     });
     await TeamMemberDAO.insert({
       member_index: 1,
       fk_team_id: 1,
-      fk_pokemon_id: 1
+      fk_pokemon_id: 1,
+      sneaky_snacking: false
     });
     await TeamMemberDAO.insert({
       member_index: 2,
       fk_team_id: 1,
-      fk_pokemon_id: 2
+      fk_pokemon_id: 2,
+      sneaky_snacking: false
     });
 
     expect(await TeamDAO.findTeamsWithMembers(1)).toMatchSnapshot();

--- a/backend/src/database/dao/team/team/team-dao.ts
+++ b/backend/src/database/dao/team/team/team-dao.ts
@@ -80,6 +80,7 @@ class TeamDAOImpl extends AbstractDAO<typeof DBTeamSchema> {
           skillLevel: member.skill_level,
           nature: member.nature,
           subskills,
+          sneakySnacking: false,
           ingredients: PokemonDAO.filterChosenIngredientList(member)
         });
       }

--- a/backend/src/database/dao/team/team/team-dao.ts
+++ b/backend/src/database/dao/team/team/team-dao.ts
@@ -80,7 +80,7 @@ class TeamDAOImpl extends AbstractDAO<typeof DBTeamSchema> {
           skillLevel: member.skill_level,
           nature: member.nature,
           subskills,
-          sneakySnacking: false,
+          sneakySnacking: memberData.sneaky_snacking,
           ingredients: PokemonDAO.filterChosenIngredientList(member)
         });
       }

--- a/backend/src/database/migration/database-migration.test.ts
+++ b/backend/src/database/migration/database-migration.test.ts
@@ -20,7 +20,7 @@ describe('Database migration', async () => {
     const migrationFilesFS: string[] = await fs.readdir(migrationsDir);
 
     expect(migrationFilesDB).toEqual(migrationFilesFS);
-    expect(migrationFilesDB).toHaveLength(12);
+    expect(migrationFilesDB).toHaveLength(13);
   });
 
   it('shall migrate database down', async () => {

--- a/backend/src/database/migration/migrations/013_team_member_add_sneaky_snacking.js
+++ b/backend/src/database/migration/migrations/013_team_member_add_sneaky_snacking.js
@@ -1,0 +1,27 @@
+const Tables = {
+  TeamMember: 'team_member'
+};
+
+export async function up(knex) {
+  // Check current state to make migration idempotent
+  const hasSneakySnacking = await knex.schema.hasColumn(Tables.TeamMember, 'sneaky_snacking');
+
+  // Add sneaky_snacking column if it doesn't exist
+  if (!hasSneakySnacking) {
+    await knex.schema.alterTable(Tables.TeamMember, (table) => {
+      table.boolean('sneaky_snacking');
+    });
+  }
+}
+
+export async function down(knex) {
+  // Check what state we're in
+  const hasSneakySnacking = await knex.schema.hasColumn(Tables.TeamMember, 'sneaky_snacking');
+
+  // Drop column if it exists
+  if (hasSneakySnacking) {
+    await knex.schema.alterTable(Tables.TeamMember, (table) => {
+      table.dropColumn('sneaky_snacking');
+    });
+  }
+}

--- a/backend/src/services/api-service/production/production-service.test.ts
+++ b/backend/src/services/api-service/production/production-service.test.ts
@@ -93,7 +93,8 @@ describe('calculateTeam', () => {
           nature: nature.MILD,
           skillLevel: 6,
           subskills: new Set([subskill.INGREDIENT_FINDER_M.name]),
-          externalId: 'some id'
+          externalId: 'some id',
+          sneakySnacking: false
         }
       }
     ];
@@ -155,7 +156,8 @@ describe('calculateIv', () => {
           nature: nature.JOLLY,
           skillLevel: 4,
           subskills: new Set([subskill.HELPING_SPEED_S.name]),
-          externalId: 'bulbasaur-1'
+          externalId: 'bulbasaur-1',
+          sneakySnacking: false
         }
       }
     ];
@@ -173,7 +175,8 @@ describe('calculateIv', () => {
           nature: nature.BRAVE,
           skillLevel: 3,
           subskills: new Set([subskill.SKILL_TRIGGER_S.name]),
-          externalId: 'charmander-variant'
+          externalId: 'charmander-variant',
+          sneakySnacking: false
         }
       }
     ];

--- a/backend/src/services/api-service/team/team-service.test.ts
+++ b/backend/src/services/api-service/team/team-service.test.ts
@@ -397,7 +397,8 @@ describe('upsertTeamMember', () => {
         { level: 0, name: 'apple', amount: 2 },
         { level: 30, name: 'apple', amount: 5 },
         { level: 60, name: 'apple', amount: 7 }
-      ]
+      ],
+      sneakySnacking: false
     };
 
     const result = await upsertTeamMember({ teamIndex: 0, memberIndex: 0, request, user });
@@ -421,7 +422,8 @@ describe('upsertTeamMember', () => {
         { level: 0, name: 'apple', amount: 2 },
         { level: 30, name: 'apple', amount: 5 },
         { level: 60, name: 'apple', amount: 7 }
-      ]
+      ],
+      sneakySnacking: false
     });
 
     expect(await PokemonDAO.get({ external_id: result.externalId })).toEqual({
@@ -509,7 +511,8 @@ describe('upsertTeamMember', () => {
         { level: 0, name: 'apple', amount: 2 },
         { level: 30, name: 'apple', amount: 5 },
         { level: 60, name: 'apple', amount: 7 }
-      ]
+      ],
+      sneakySnacking: false
     };
 
     // should get updated to version 2
@@ -570,7 +573,8 @@ describe('upsertTeamMember', () => {
         { level: 0, name: 'apple', amount: 2 },
         { level: 30, name: 'apple', amount: 5 },
         { level: 60, name: 'apple', amount: 7 }
-      ]
+      ],
+      sneakySnacking: false
     });
 
     expect(await PokemonDAO.get({ external_id: result.externalId })).toEqual({
@@ -654,7 +658,8 @@ describe('upsertTeamMember', () => {
         { level: 0, name: 'apple', amount: 2 },
         { level: 30, name: 'apple', amount: 5 }
         // Missing ingredient for level 60
-      ]
+      ],
+      sneakySnacking: false
     };
 
     await expect(upsertTeamMember({ teamIndex: 0, memberIndex: 0, request, user })).rejects.toThrow(IngredientError);

--- a/backend/src/services/api-service/team/team-service.test.ts
+++ b/backend/src/services/api-service/team/team-service.test.ts
@@ -457,7 +457,8 @@ describe('upsertTeamMember', () => {
         fk_pokemon_id: 1,
         member_index: 0,
         id: 1,
-        version: 1
+        version: 1,
+        sneaky_snacking: false
       }
     ]);
 
@@ -607,7 +608,8 @@ describe('upsertTeamMember', () => {
       fk_pokemon_id: 1,
       member_index: 0,
       id: 1,
-      version: 1
+      version: 1,
+      sneaky_snacking: false
     });
 
     expect(await TeamDAO.findMultiple()).toEqual([
@@ -710,7 +712,12 @@ describe('deleteMember', () => {
       ingredient_60: 'pearl'
     });
 
-    await TeamMemberDAO.insert({ fk_team_id: team.id, fk_pokemon_id: pokemon.id, member_index: 0 });
+    await TeamMemberDAO.insert({
+      fk_team_id: team.id,
+      fk_pokemon_id: pokemon.id,
+      member_index: 0,
+      sneaky_snacking: false
+    });
 
     await deleteMember({ teamIndex: 0, memberIndex: 0, user });
 
@@ -761,7 +768,12 @@ describe('deleteMember', () => {
       ingredient_60: 'pearl'
     });
 
-    await TeamMemberDAO.insert({ fk_team_id: team.id, fk_pokemon_id: pokemon.id, member_index: 0 });
+    await TeamMemberDAO.insert({
+      fk_team_id: team.id,
+      fk_pokemon_id: pokemon.id,
+      member_index: 0,
+      sneaky_snacking: false
+    });
 
     await deleteMember({ teamIndex: 0, memberIndex: 0, user });
 
@@ -824,13 +836,23 @@ describe('deleteMember', () => {
       ingredient_60: 'pearl'
     });
 
-    await TeamMemberDAO.insert({ fk_team_id: team1.id, fk_pokemon_id: pokemon.id, member_index: 0 });
-    await TeamMemberDAO.insert({ fk_team_id: team2.id, fk_pokemon_id: pokemon.id, member_index: 1 });
+    await TeamMemberDAO.insert({
+      fk_team_id: team1.id,
+      fk_pokemon_id: pokemon.id,
+      member_index: 0,
+      sneaky_snacking: false
+    });
+    await TeamMemberDAO.insert({
+      fk_team_id: team2.id,
+      fk_pokemon_id: pokemon.id,
+      member_index: 1,
+      sneaky_snacking: false
+    });
 
     await deleteMember({ teamIndex: 0, memberIndex: 0, user });
 
     expect(await TeamMemberDAO.findMultiple()).toEqual([
-      { fk_team_id: team2.id, fk_pokemon_id: pokemon.id, member_index: 1, id: 2, version: 1 }
+      { fk_team_id: team2.id, fk_pokemon_id: pokemon.id, member_index: 1, id: 2, version: 1, sneaky_snacking: false }
     ]);
     expect(await PokemonDAO.findMultiple()).toEqual([pokemon]);
   });
@@ -875,7 +897,8 @@ describe('deleteTeam', () => {
     await TeamMemberDAO.insert({
       fk_pokemon_id: pkmn.id,
       fk_team_id: team.id,
-      member_index: 0
+      member_index: 0,
+      sneaky_snacking: false
     });
 
     await deleteTeam(team.team_index, user);
@@ -943,7 +966,8 @@ describe('deleteTeam', () => {
     await TeamMemberDAO.insert({
       fk_pokemon_id: pkmn.id,
       fk_team_id: team.id,
-      member_index: 0
+      member_index: 0,
+      sneaky_snacking: false
     });
 
     await deleteTeam(team.team_index, user);

--- a/backend/src/services/api-service/team/team-service.ts
+++ b/backend/src/services/api-service/team/team-service.ts
@@ -180,7 +180,8 @@ export async function upsertTeamMember(params: {
       skillLevel: upsertedMember.skill_level,
       nature: upsertedMember.nature,
       subskills: request.subskills,
-      ingredients: request.ingredients
+      ingredients: request.ingredients,
+      sneakySnacking: request.sneakySnacking
     };
   });
 }

--- a/backend/src/services/api-service/team/team-service.ts
+++ b/backend/src/services/api-service/team/team-service.ts
@@ -160,7 +160,12 @@ export async function upsertTeamMember(params: {
     });
 
     const updatedMemberMeta = await TeamMemberDAO.upsert({
-      updated: { fk_pokemon_id: upsertedMember.id, fk_team_id: team.id, member_index: memberIndex },
+      updated: {
+        fk_pokemon_id: upsertedMember.id,
+        fk_team_id: team.id,
+        member_index: memberIndex,
+        sneaky_snacking: request.sneakySnacking
+      },
       filter: { fk_team_id: team.id, member_index: memberIndex },
       options: { trx }
     });

--- a/backend/src/services/simulation-service/team-simulator/member-state/member-state.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/member-state/member-state.test.ts
@@ -50,7 +50,8 @@ const guaranteedSkillProcMember: TeamMemberExt = {
     nature: nature.BASHFUL,
     skillLevel: 6,
     subskills: new Set(),
-    externalId: 'some id'
+    externalId: 'some id',
+    sneakySnacking: false
   }
 };
 
@@ -63,7 +64,8 @@ const member: TeamMemberExt = {
     nature: nature.BASHFUL,
     skillLevel: 6,
     subskills: new Set(),
-    externalId: 'some id'
+    externalId: 'some id',
+    sneakySnacking: false
   }
 };
 
@@ -214,7 +216,8 @@ describe('startDay', () => {
         nature: nature.MILD,
         skillLevel: 6,
         subskills: new Set(),
-        externalId: 'some id'
+        externalId: 'some id',
+        sneakySnacking: false
       }
     };
 
@@ -235,7 +238,8 @@ describe('startDay', () => {
         nature: nature.MILD,
         skillLevel: 6,
         subskills: new Set(),
-        externalId: 'some id'
+        externalId: 'some id',
+        sneakySnacking: false
       }
     };
 
@@ -268,7 +272,8 @@ describe('startDay', () => {
         nature: nature.MILD,
         skillLevel: 6,
         subskills: new Set(),
-        externalId: 'some id'
+        externalId: 'some id',
+        sneakySnacking: false
       }
     };
     const teammate: TeamMemberExt = {
@@ -296,7 +301,8 @@ describe('startDay', () => {
         nature: nature.BASHFUL,
         skillLevel: 6,
         subskills: new Set([subskill.ENERGY_RECOVERY_BONUS.name]),
-        externalId: 'some id'
+        externalId: 'some id',
+        sneakySnacking: false
       }
     };
 
@@ -328,7 +334,8 @@ describe('recoverEnergy', () => {
         nature: nature.MILD,
         skillLevel: 6,
         subskills: new Set(),
-        externalId: 'some id'
+        externalId: 'some id',
+        sneakySnacking: false
       }
     };
 
@@ -397,7 +404,8 @@ describe('attemptDayHelp', () => {
         nature: nature.BASHFUL,
         skillLevel: 6,
         subskills: new Set(),
-        externalId: 'some id'
+        externalId: 'some id',
+        sneakySnacking: false
       }
     };
 
@@ -477,7 +485,8 @@ describe('attemptDayHelp', () => {
         nature: nature.BASHFUL,
         skillLevel: 6,
         subskills: new Set(),
-        externalId: 'some id'
+        externalId: 'some id',
+        sneakySnacking: false
       }
     };
     const memberState = new MemberState({ member, settings, team: [member], cookingState });
@@ -534,7 +543,8 @@ describe('attemptNightHelp', () => {
         nature: nature.BASHFUL,
         skillLevel: 6,
         subskills: new Set(),
-        externalId: 'some id'
+        externalId: 'some id',
+        sneakySnacking: false
       }
     };
     const memberState = new MemberState({ member, settings, team: [member], cookingState });

--- a/backend/src/services/simulation-service/team-simulator/team-simulator-benchmark.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator-benchmark.test.ts
@@ -64,7 +64,8 @@ function randomTeamMemberSettings(pokemon: Pokemon): TeamMemberSettingsExt {
     skillLevel: (rng.getUint8() % pokemon.skill.maxLevel) + 1,
     carrySize: CarrySizeUtils.baseCarrySize(pokemon),
     ribbon: 0,
-    externalId: 'something' + rng.getUint8() + rng.getUint8() + rng.getUint8() + rng.getUint8() + rng.getUint8()
+    externalId: 'something' + rng.getUint8() + rng.getUint8() + rng.getUint8() + rng.getUint8() + rng.getUint8(),
+    sneakySnacking: false
   };
 }
 

--- a/backend/src/services/simulation-service/team-simulator/team-simulator-utils.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator-utils.test.ts
@@ -83,7 +83,8 @@ describe('calculateAverageProduce', () => {
         nature: optimalSettings.nature,
         subskills: new Set(optimalSettings.subskills.map((s) => s.subskill.name).slice(0, 2)),
         level: 29,
-        externalId: 'optimal'
+        externalId: 'optimal',
+        sneakySnacking: false
       };
 
       const averageProduce60 = TeamSimulatorUtils.calculateAverageProduce({
@@ -103,7 +104,8 @@ describe('calculateAverageProduce', () => {
         nature: optimalSettings.nature,
         subskills: new Set(optimalSettings.subskills.map((s) => s.subskill.name).slice(0, 2)),
         level: 30,
-        externalId: 'optimal'
+        externalId: 'optimal',
+        sneakySnacking: false
       };
 
       const averageProduce60 = TeamSimulatorUtils.calculateAverageProduce({
@@ -123,7 +125,8 @@ describe('calculateAverageProduce', () => {
         nature: optimalSettings.nature,
         subskills: new Set(optimalSettings.subskills.map((s) => s.subskill.name).slice(0, 3)),
         level: 60,
-        externalId: 'optimal'
+        externalId: 'optimal',
+        sneakySnacking: false
       };
       // ing% = 1.54 * 1.2 * 0.266 = 0.49 = 49%
       // (2+5+7 / 3) = 4.7 ings per ing drop
@@ -143,7 +146,8 @@ describe('calculateAverageProduce', () => {
         nature: optimalSettings.nature,
         subskills: new Set(optimalSettings.subskills.map((s) => s.subskill.name).slice(0, 4)),
         level: 75,
-        externalId: 'optimal'
+        externalId: 'optimal',
+        sneakySnacking: false
       };
 
       const averageProduce60 = TeamSimulatorUtils.calculateAverageProduce({ ...member, settings });
@@ -160,7 +164,8 @@ describe('calculateAverageProduce', () => {
         nature: optimalSettings.nature,
         subskills: new Set(optimalSettings.subskills.map((s) => s.subskill.name)),
         level: 100,
-        externalId: 'optimal'
+        externalId: 'optimal',
+        sneakySnacking: false
       };
       // ing% = 1.54 * 1.2 * 0.266 = 0.49 = 49%
       // (2+5+7 / 3) = 4.7 ings per ing drop

--- a/backend/src/services/simulation-service/team-simulator/team-simulator.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator.test.ts
@@ -48,7 +48,8 @@ const mockMembers: TeamMemberExt[] = [
       nature: nature.BASHFUL,
       skillLevel: 6,
       subskills: new Set(),
-      externalId: 'some id'
+      externalId: 'some id',
+      sneakySnacking: false
     }
   }
 ];
@@ -103,7 +104,8 @@ describe('TeamSimulator', () => {
           nature: nature.MILD,
           skillLevel: 6,
           subskills: new Set([subskill.INGREDIENT_FINDER_M.name]),
-          externalId: 'some id'
+          externalId: 'some id',
+          sneakySnacking: false
         }
       }
     ];
@@ -128,7 +130,8 @@ describe('TeamSimulator', () => {
         nature: nature.BASHFUL,
         skillLevel: 6,
         subskills: new Set(),
-        externalId: 'some id'
+        externalId: 'some id',
+        sneakySnacking: false
       }
     };
 
@@ -172,7 +175,8 @@ describe('TeamSimulator', () => {
         nature: nature.BASHFUL,
         skillLevel: 6,
         subskills: new Set(),
-        externalId: 'some id'
+        externalId: 'some id',
+        sneakySnacking: false
       }
     };
     const mockMemberSupport: TeamMemberExt = {
@@ -187,7 +191,8 @@ describe('TeamSimulator', () => {
         nature: nature.BASHFUL,
         skillLevel: 6,
         subskills: new Set(),
-        externalId: 'some id'
+        externalId: 'some id',
+        sneakySnacking: false
       }
     };
 
@@ -218,7 +223,8 @@ describe('TeamSimulator', () => {
         nature: nature.ADAMANT,
         skillLevel: EnergyForEveryone.maxLevel,
         subskills: new Set([subskill.HELPING_SPEED_M.name]),
-        externalId: 'some id'
+        externalId: 'some id',
+        sneakySnacking: false
       }
     };
 
@@ -262,7 +268,8 @@ describe('TeamSimulator', () => {
           nature: nature.BASHFUL,
           skillLevel: 6,
           subskills: new Set(),
-          externalId: 'some id'
+          externalId: 'some id',
+          sneakySnacking: false
         }
       }
     ];
@@ -308,7 +315,8 @@ describe('TeamSimulator', () => {
           nature: nature.BASHFUL,
           skillLevel: 6,
           subskills: new Set(),
-          externalId: 'some id'
+          externalId: 'some id',
+          sneakySnacking: false
         }
       }
     ];
@@ -359,6 +367,7 @@ describe('TeamSimulator', () => {
         nature: nature.BASHFUL,
         skillLevel: 3,
         subskills: new Set(),
+        sneakySnacking: false,
         externalId: 'event-test'
       }
     };

--- a/backend/src/services/solve/utils/__snapshots__/solve-utils.test.ts.snap
+++ b/backend/src/services/solve/utils/__snapshots__/solve-utils.test.ts.snap
@@ -18,6 +18,7 @@ exports[`solve-utils > bogusMembers > should create an array of mocked Pokémon 
   },
   "ribbon": 0,
   "skillLevel": 1,
+  "sneakySnacking": false,
   "subskills": Set {},
 }
 `;

--- a/backend/src/services/solve/utils/solve-utils.ts
+++ b/backend/src/services/solve/utils/solve-utils.ts
@@ -203,7 +203,12 @@ export function pokedexToMembers(params: { pokedex: Pokedex; level: number; camp
     const optimalSettings: Optimal = isSupportSkillMon
       ? Optimal.skill(pkmn, 4, pkmn.skill.maxLevel)
       : Optimal.ingredient(pkmn, 4, pkmn.skill.maxLevel);
-    const settings = Optimal.toMemberSettings({ stats: optimalSettings, level, externalId: pkmn.name });
+    const settings = Optimal.toMemberSettings({
+      stats: optimalSettings,
+      level,
+      externalId: pkmn.name,
+      sneakySnacking: false // for cooking, sneaky snacking is always worse
+    });
 
     // TODO: this should probably be moved to member-state constructor
     settings.carrySize = CarrySizeUtils.calculateCarrySize({

--- a/backend/src/services/user-service/user-pokemon-service/user-pokemon-service.test.ts
+++ b/backend/src/services/user-service/user-pokemon-service/user-pokemon-service.test.ts
@@ -52,6 +52,7 @@ describe('upsertPokemon', () => {
     gender: 'female',
     skillLevel: 0,
     subskills: [],
+    sneakySnacking: false,
     version: 0
   };
   it('shall insert pokemon if not exists and saved is true', async () => {

--- a/backend/src/services/user-service/user-pokemon-service/user-pokemon.ts
+++ b/backend/src/services/user-service/user-pokemon-service/user-pokemon.ts
@@ -21,7 +21,7 @@ export async function getSavedPokemon(user: DBUser): Promise<PokemonInstanceWith
     nature: pkmn.nature,
     subskills: PokemonDAO.filterFilledSubskills(pkmn),
     ingredients: PokemonDAO.filterChosenIngredientList(pkmn),
-    sneakySnacking: false // default team members to not sneaky snacking
+    sneakySnacking: false // default box mons to not sneaky snacking
   }));
 }
 

--- a/backend/src/services/user-service/user-pokemon-service/user-pokemon.ts
+++ b/backend/src/services/user-service/user-pokemon-service/user-pokemon.ts
@@ -20,7 +20,8 @@ export async function getSavedPokemon(user: DBUser): Promise<PokemonInstanceWith
     skillLevel: pkmn.skill_level,
     nature: pkmn.nature,
     subskills: PokemonDAO.filterFilledSubskills(pkmn),
-    ingredients: PokemonDAO.filterChosenIngredientList(pkmn)
+    ingredients: PokemonDAO.filterChosenIngredientList(pkmn),
+    sneakySnacking: false // default team members to not sneaky snacking
   }));
 }
 

--- a/backend/src/vitest/mocks/team/mock-team-member-settings-ext.ts
+++ b/backend/src/vitest/mocks/team/mock-team-member-settings-ext.ts
@@ -10,6 +10,7 @@ export function teamMemberSettings(attrs?: Partial<TeamMemberSettings>): TeamMem
     ribbon: 0,
     skillLevel: 0,
     subskills: [],
+    sneakySnacking: false,
     ...attrs
   };
 }
@@ -23,6 +24,7 @@ export function teamMemberSettingsExt(attrs?: Partial<TeamMemberSettingsExt>): T
     ribbon: 0,
     skillLevel: 1,
     subskills: new Set(),
+    sneakySnacking: false,
     ...attrs
   };
 }
@@ -36,6 +38,7 @@ export function teamMemberSettingsResult(attrs?: Partial<TeamMemberSettingsResul
     ribbon: 0,
     skillLevel: 0,
     subskills: [],
+    sneakySnacking: false,
     ...attrs
   };
 }

--- a/common/src/types/instance/pokemon-instance.ts
+++ b/common/src/types/instance/pokemon-instance.ts
@@ -13,6 +13,7 @@ export interface PokemonInstanceBase<PokemonType, NatureType, SubskillType, Ingr
   nature: NatureType;
   subskills: SubskillType[];
   ingredients: IngredientType[];
+  sneakySnacking: boolean;
 }
 export type PokemonInstance = PokemonInstanceBase<
   string, // Pokemon as a simple string ID

--- a/common/src/types/optimal/optimal.test.ts
+++ b/common/src/types/optimal/optimal.test.ts
@@ -126,7 +126,8 @@ describe('Optimal', () => {
       const memberSettings = Optimal.toMemberSettings({
         stats: optimalStats,
         level: 50,
-        externalId: 'test-id'
+        externalId: 'test-id',
+        sneakySnacking: true
       });
 
       expect(memberSettings).toEqual({
@@ -136,7 +137,8 @@ describe('Optimal', () => {
         skillLevel: mockedPokemon.skill.maxLevel,
         subskills: new Set(optimalStats.subskills.slice(0, 3).map((subskill) => subskill.subskill.name)),
         level: 50,
-        externalId: 'test-id'
+        externalId: 'test-id',
+        sneakySnacking: true
       });
     });
 
@@ -158,7 +160,8 @@ describe('Optimal', () => {
       const memberSettings = Optimal.toMemberSettings({
         stats: optimalStats,
         level: 75,
-        externalId: 'test-id-2'
+        externalId: 'test-id-2',
+        sneakySnacking: false
       });
 
       expect(memberSettings).toEqual({
@@ -168,7 +171,8 @@ describe('Optimal', () => {
         skillLevel: mockedPokemon.skill.maxLevel,
         subskills: new Set(optimalStats.subskills.slice(0, 4).map((subskill) => subskill.subskill.name)),
         level: 75,
-        externalId: 'test-id-2'
+        externalId: 'test-id-2',
+        sneakySnacking: false
       });
     });
   });

--- a/common/src/types/optimal/optimal.ts
+++ b/common/src/types/optimal/optimal.ts
@@ -77,8 +77,13 @@ class OptimalImpl {
    * Filters subskills on level
    * @returns {TeamMemberSettingsExt}
    */
-  public toMemberSettings(params: { stats: Optimal; level: number; externalId: string }): TeamMemberSettingsExt {
-    const { stats, level, externalId } = params;
+  public toMemberSettings(params: {
+    stats: Optimal;
+    level: number;
+    externalId: string;
+    sneakySnacking: boolean;
+  }): TeamMemberSettingsExt {
+    const { stats, level, externalId, sneakySnacking } = params;
 
     const subskills = new Set<string>();
     for (const subskill of stats.subskills) {
@@ -94,7 +99,8 @@ class OptimalImpl {
       skillLevel: stats.skillLevel,
       subskills,
       level,
-      externalId
+      externalId,
+      sneakySnacking
     };
   }
 }

--- a/common/src/types/team/member.ts
+++ b/common/src/types/team/member.ts
@@ -10,6 +10,7 @@ export interface TeamMemberSettings {
   carrySize: number;
   ribbon: number;
   externalId: string;
+  sneakySnacking: boolean;
 }
 export interface TeamMemberSettingsExt {
   level: number;
@@ -19,6 +20,7 @@ export interface TeamMemberSettingsExt {
   carrySize: number;
   ribbon: number;
   externalId: string;
+  sneakySnacking: boolean;
 }
 
 export interface TeamMember {

--- a/common/src/utils/rp-utils/rp.test.ts
+++ b/common/src/utils/rp-utils/rp.test.ts
@@ -58,7 +58,8 @@ const baseInstance: PokemonInstanceWithoutRP = {
   version: 0,
   saved: false,
   shiny: false,
-  gender: undefined
+  gender: undefined,
+  sneakySnacking: false
 };
 
 describe('RP', () => {

--- a/common/src/vitest/mocks/pokemon/mock-pokemon-instance.ts
+++ b/common/src/vitest/mocks/pokemon/mock-pokemon-instance.ts
@@ -12,6 +12,7 @@ export function pokemonInstance(attrs?: Partial<PokemonInstance>): PokemonInstan
     nature: 'normal',
     subskills: [],
     ingredients: [],
+    sneakySnacking: false,
     ...attrs
   };
 }

--- a/common/src/vitest/mocks/team/mock-team-member-settings-ext.ts
+++ b/common/src/vitest/mocks/team/mock-team-member-settings-ext.ts
@@ -10,6 +10,7 @@ export function teamMemberSettingsExt(attrs?: Partial<TeamMemberSettingsExt>): T
     ribbon: 0,
     skillLevel: 1,
     subskills: new Set(),
+    sneakySnacking: false,
     ...attrs
   };
 }

--- a/common/src/vitest/mocks/tierlist/mock-tierlist.ts
+++ b/common/src/vitest/mocks/tierlist/mock-tierlist.ts
@@ -34,7 +34,8 @@ export function pokemonWithTiering(attrs?: Partial<PokemonWithTiering>): Pokemon
         skillLevel: 6,
         carrySize: 10,
         ribbon: 0,
-        externalId: 'pikachu-1'
+        externalId: 'pikachu-1',
+        sneakySnacking: false
       }
     },
     contributions: [],
@@ -78,7 +79,8 @@ export function multiplePokemonWithTiering(count: number = 4): PokemonWithTierin
             skillLevel: 4 + Math.floor(i / 2),
             carrySize: 8 + i,
             ribbon: 0,
-            externalId: `${pokemon.name.toLowerCase()}-${i + 1}`
+            externalId: `${pokemon.name.toLowerCase()}-${i + 1}`,
+            sneakySnacking: false
           }
         },
         score: baseScore,

--- a/frontend/src/components/compare/compare-strength.vue
+++ b/frontend/src/components/compare/compare-strength.vue
@@ -304,7 +304,7 @@ export default defineComponent({
                 skillActivation,
                 amount: (() => {
                   const value = memberProduction.skillValue[skillActivation.unit as MainskillUnit]
-                  return value.amountToSelf + value.amountToTeam
+                  return value ? value.amountToSelf + value.amountToTeam : 0
                 })(),
                 timeWindow,
                 areaBonus

--- a/frontend/src/components/tierlist/tabs/OverviewTab.test.ts
+++ b/frontend/src/components/tierlist/tabs/OverviewTab.test.ts
@@ -44,7 +44,8 @@ describe('OverviewTab.vue', () => {
           skillLevel: 6,
           carrySize: 15,
           ribbon: 4,
-          externalId: 'pikachu-1'
+          externalId: 'pikachu-1',
+          sneakySnacking: false
         }
       }
     })
@@ -200,7 +201,8 @@ describe('OverviewTab.vue', () => {
             skillLevel: 1,
             carrySize: 5,
             ribbon: 0,
-            externalId: 'bulbasaur-1'
+            externalId: 'bulbasaur-1',
+            sneakySnacking: false
           }
         }
       })

--- a/frontend/src/services/team/team-service.test.ts
+++ b/frontend/src/services/team/team-service.test.ts
@@ -135,7 +135,8 @@ describe('getTeams', () => {
               { level: 0, name: ingredient.FANCY_APPLE.name, amount: 2 },
               { level: 30, name: ingredient.FANCY_APPLE.name, amount: 5 },
               { level: 60, name: ingredient.FANCY_APPLE.name, amount: 7 }
-            ]
+            ],
+            sneakySnacking: false
           }
         ]
       }
@@ -286,7 +287,8 @@ describe('createOrUpdateMember', () => {
         level: ingredientSet.level,
         name: ingredientSet.ingredient.name,
         amount: ingredientSet.amount
-      }))
+      })),
+      sneakySnacking: false
     })
   })
 
@@ -318,7 +320,8 @@ describe('createOrUpdateMember', () => {
         level: ingredientSet.level,
         name: ingredientSet.ingredient.name,
         amount: ingredientSet.amount
-      }))
+      })),
+      sneakySnacking: false
     })
   })
 })
@@ -410,7 +413,8 @@ describe('calculateProduction', () => {
           level: i.level,
           name: i.ingredient.name,
           amount: i.amount
-        }))
+        })),
+        sneakySnacking: false
       })),
       settings
     })
@@ -516,7 +520,8 @@ describe('calculateIv', () => {
             level: i.level,
             name: i.ingredient.name,
             amount: i.amount
-          }))
+          })),
+          sneakySnacking: false
         }
       ],
       variants: expect.any(Array),

--- a/frontend/src/services/utils/pokemon-instance-utils.test.ts
+++ b/frontend/src/services/utils/pokemon-instance-utils.test.ts
@@ -41,7 +41,8 @@ const mockPokemonInstanceWithMeta: PokemonInstanceWithMeta = {
     { level: 0, name: 'Apple', amount: 2 },
     { level: 30, name: 'Apple', amount: 5 },
     { level: 60, name: 'Apple', amount: 7 }
-  ]
+  ],
+  sneakySnacking: false
 }
 
 describe('toPokemonInstanceExt', () => {
@@ -133,7 +134,8 @@ describe('toPokemonInstanceIdentity', () => {
       level: mockPokemonInstanceExt.level,
       ribbon: mockPokemonInstanceExt.ribbon,
       skillLevel: mockPokemonInstanceExt.skillLevel,
-      externalId: mockPokemonInstanceExt.externalId
+      externalId: mockPokemonInstanceExt.externalId,
+      sneakySnacking: false
     })
   })
 })

--- a/frontend/src/services/utils/pokemon-instance-utils.ts
+++ b/frontend/src/services/utils/pokemon-instance-utils.ts
@@ -37,6 +37,7 @@ class PokemonInstanceUtilsImpl {
         { ...pokemon.ingredient30[0], level: 30 },
         { ...pokemon.ingredient60[0], level: 60 }
       ],
+      sneakySnacking: false,
       rp: 0,
       version: 0,
       ...attrs,
@@ -101,7 +102,8 @@ class PokemonInstanceUtilsImpl {
         level: instancedIngredient.level,
         ingredient: getIngredient(instancedIngredient.name),
         amount: instancedIngredient.amount
-      }))
+      })),
+      sneakySnacking: pokemonInstance.sneakySnacking
     }
     return {
       ...pokemonWithoutRP,
@@ -139,7 +141,8 @@ class PokemonInstanceUtilsImpl {
         level: instancedIngredient.level,
         name: instancedIngredient.ingredient.name,
         amount: instancedIngredient.amount
-      }))
+      })),
+      sneakySnacking: instancedPokemon.sneakySnacking
     }
   }
 
@@ -160,6 +163,7 @@ class PokemonInstanceUtilsImpl {
       level: pokemonInstance.level,
       ribbon: pokemonInstance.ribbon,
       skillLevel: pokemonInstance.skillLevel,
+      sneakySnacking: pokemonInstance.sneakySnacking,
       externalId: pokemonInstance.externalId
     }
   }

--- a/frontend/src/vitest/mocks/pokemon-instance.ts
+++ b/frontend/src/vitest/mocks/pokemon-instance.ts
@@ -19,6 +19,7 @@ export function createMockPokemon(attrs?: Partial<PokemonInstanceExt>): PokemonI
     gender: undefined,
     skillLevel: 1,
     subskills: [],
+    sneakySnacking: false,
     version: 1,
     rp: 0,
     ...attrs


### PR DESCRIPTION
Add a `sneakySnacking` boolean to `TeamMemberSettings`. In `member-state.ts`, if the member is sneaky snacking, don't roll ingredients for normal helps, and never activate skills.

Ran the benchmarking tests for the team simulator. The results are consistent, and the runs took about the same amount of time.