### PR TITLE
fix: bugs in moonlight and berry juice

### DIFF
--- a/backend/src/services/calculator/skill/activation/__snapshots__/skill-activation.test.ts.snap
+++ b/backend/src/services/calculator/skill/activation/__snapshots__/skill-activation.test.ts.snap
@@ -1262,7 +1262,7 @@ exports[`activateMetronome > shall use the correct metronomeFactor for each skil
       ],
       "image": "energy",
       "juiceAmount": 1,
-      "juicePercent": 0,
+      "juicePercent": 0.185,
       "modifierName": "Berry Juice",
     },
   },

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/charge-energy-s-moonlight-effect.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/charge-energy-s-moonlight-effect.test.ts
@@ -56,6 +56,6 @@ describe('ChargeEnergySMoonlightEffect', () => {
     expect(activation.activations[0].self?.regular).toBeGreaterThan(0);
     expect(activation.activations[0].self?.crit).toBe(0);
     expect(activation.activations[0].team?.crit).toBe(teamAmount);
-    expect(activation.activations[0].team?.chanceToTargetLowestMember).toBe(1 / skillState.memberState.teamSize);
+    expect(activation.activations[0].team?.chanceToTargetLowestMember).toBe(0.5);
   });
 });

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/charge-energy-s-moonlight-effect.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/charge-energy-s-moonlight-effect.ts
@@ -19,7 +19,6 @@ export class ChargeEnergySMoonlightEffect implements SkillEffect {
     if (skillState.rng() < ChargeEnergySMoonlight.activations.energy.critChance!) {
       const teamAmount = ChargeEnergySMoonlight.activations.energy.critAmount!({ skillLevel: skillState.skillLevel });
 
-      // currently uses equal chance to hit every member
       return {
         skill,
         activations: [
@@ -29,7 +28,7 @@ export class ChargeEnergySMoonlightEffect implements SkillEffect {
             team: {
               regular: 0,
               crit: teamAmount,
-              chanceToTargetLowestMember: 1 / skillState.memberState.teamSize
+              chanceToTargetLowestMember: 0.5
             }
           }
         ]

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/energy-for-everyone-berry-juice-effect.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/energy-for-everyone-berry-juice-effect.test.ts
@@ -16,8 +16,7 @@ describe('EnergyForEveryoneBerryJuiceEffect', () => {
     effect = new EnergyForEveryoneBerryJuiceEffect();
   });
 
-  // TODO: Enable this test once real numbers are known.
-  it.skip('should create an item with a successful roll', () => {
+  it('should create an item with a successful roll', () => {
     const alwaysSucceed = 0;
     vimic(skillState, 'rng', () => alwaysSucceed);
 

--- a/common/src/types/mainskill/mainskills/energy-for-everyone-berry-juice.ts
+++ b/common/src/types/mainskill/mainskills/energy-for-everyone-berry-juice.ts
@@ -11,7 +11,7 @@ export const EnergyForEveryoneBerryJuice = new (class extends ModifiedMainskill 
     `Restores ${this.energyAmounts[params.skillLevel - 1]} Energy to all helper Pokémon on your team. Sometimes additionally gets you a Berry Juice.`;
   RP = [1220, 1735, 2392, 3303, 4559, 6299];
 
-  juicePercent: number = 0; // TODO: Replace once real numbers are known.
+  juicePercent: number = 0.185;
   juiceAmount: number = 1;
 
   activations: ActivationsType = {

--- a/common/src/types/pokemon/__snapshots__/pokemon.test.ts.snap
+++ b/common/src/types/pokemon/__snapshots__/pokemon.test.ts.snap
@@ -24058,7 +24058,7 @@ exports[`COMPLETE_POKEDEX > shall not change SHUCKLE unexpectedly 1`] = `
     ],
     "image": "energy",
     "juiceAmount": 1,
-    "juicePercent": 0,
+    "juicePercent": 0.185,
     "modifierName": "Berry Juice",
   },
   "skillPercentage": 5.9,

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-juice-energy-for-everyone-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-juice-energy-for-everyone-details.test.ts
@@ -67,17 +67,13 @@ describe('BerryJuiceEnergyForEveryoneDetails', () => {
       skillLevel: mockMember.member.skillLevel
     })
     const juicePercent = EnergyForEveryoneBerryJuice.juicePercent
-    expect(skillValuePerProc.text()).toBe(`x${juicePerSuccess * juicePercent}`)
+    const roundedJuicePerProc = compactNumber(MathUtils.round(juicePerSuccess * juicePercent, 2))
+    expect(skillValuePerProc.text()).toBe(`x${roundedJuicePerProc}`)
   })
 
   it('displays the correct total energy value', () => {
     const totalEnergyValue = wrapper.find('.energy-total')
     const expectedValue = mockMember.production.skillValue.energy.amountToTeam * timeWindowFactor('24H')
     expect(totalEnergyValue.text()).toContain(compactNumber(expectedValue))
-  })
-
-  it('displays the correct total energy value', () => {
-    const totalEnergyValue = wrapper.find('.juice-total')
-    expect(totalEnergyValue.text()).toContain('Unknown total')
   })
 })

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-juice-energy-for-everyone-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-juice-energy-for-everyone-details.vue
@@ -101,7 +101,7 @@ export default defineComponent({
     },
     totalJuice() {
       const juiceAmount = MathUtils.round(this.memberWithProduction.production.skillValue.items?.amountToSelf ?? 0, 2)
-      return juiceAmount > 0 ? compactNumber(juiceAmount) : 'Unknown'
+      return compactNumber(juiceAmount)
     },
     timeWindowFactor() {
       return this.teamStore.timeWindowFactor


### PR DESCRIPTION
* Berry Juice's juice% is studied at 18.5%, per RaenonX.
* Moonlight's chance to target lowest member is bugged. In an attempt to give no extra weight to the lowest energy mon (which would be achieved by setting `chanceToTargetLowestMembers` to 0), it has been set dynamically to 1/N, where N is the team size. It should be 50% like everything else that restores energy to one random mon.