### PR TITLE
refactor: team skill targeting

### DIFF
--- a/backend/src/services/calculator/skill/activation/__snapshots__/skill-activation.test.ts.snap
+++ b/backend/src/services/calculator/skill/activation/__snapshots__/skill-activation.test.ts.snap
@@ -156,6 +156,10 @@ exports[`activateMetronome > shall use the correct metronomeFactor for each skil
       ],
       "image": "energy",
       "modifierName": "Moonlight",
+      "targeting": {
+        "chanceToTargetLowestMembers": 0.5,
+        "numMonsTargeted": 1,
+      },
     },
   },
   {
@@ -930,7 +934,6 @@ exports[`activateMetronome > shall use the correct metronomeFactor for each skil
       "activations": {
         "paired": {
           "amount": [Function],
-          "targetLowestChance": 0.5,
           "unit": "energy",
         },
         "solo": {
@@ -989,6 +992,10 @@ exports[`activateMetronome > shall use the correct metronomeFactor for each skil
         20,
         24,
       ],
+      "targeting": {
+        "chanceToTargetLowestMembers": 0.5,
+        "numMonsTargeted": 1,
+      },
     },
   },
   {
@@ -1079,7 +1086,6 @@ exports[`activateMetronome > shall use the correct metronomeFactor for each skil
       "activations": {
         "energy": {
           "amount": [Function],
-          "targetLowestChance": 0.5,
           "unit": "energy",
         },
       },
@@ -1094,6 +1100,10 @@ exports[`activateMetronome > shall use the correct metronomeFactor for each skil
       ],
       "image": "energy",
       "name": "Energizing Cheer S",
+      "targeting": {
+        "chanceToTargetLowestMembers": 0.5,
+        "numMonsTargeted": 1,
+      },
     },
   },
   {
@@ -1112,7 +1122,6 @@ exports[`activateMetronome > shall use the correct metronomeFactor for each skil
       "activations": {
         "energy": {
           "amount": [Function],
-          "targetLowestChance": 0.5,
           "unit": "energy",
         },
         "skillHelps": {
@@ -1132,7 +1141,6 @@ exports[`activateMetronome > shall use the correct metronomeFactor for each skil
         "activations": {
           "energy": {
             "amount": [Function],
-            "targetLowestChance": 0.5,
             "unit": "energy",
           },
         },
@@ -1147,6 +1155,10 @@ exports[`activateMetronome > shall use the correct metronomeFactor for each skil
         ],
         "image": "energy",
         "name": "Energizing Cheer S",
+        "targeting": {
+          "chanceToTargetLowestMembers": 0.5,
+          "numMonsTargeted": 1,
+        },
       },
       "description": [Function],
       "energyAmounts": [
@@ -1167,6 +1179,10 @@ exports[`activateMetronome > shall use the correct metronomeFactor for each skil
         5,
         6,
       ],
+      "targeting": {
+        "chanceToTargetLowestMembers": 0.5,
+        "numMonsTargeted": 1,
+      },
     },
   },
   {
@@ -1473,6 +1489,10 @@ exports[`activateMetronome > shall use the correct metronomeFactor for each skil
       ],
       "image": "helps",
       "name": "Extra Helpful S",
+      "targeting": {
+        "chanceToTargetLowestMembers": 0,
+        "numMonsTargeted": 1,
+      },
     },
   },
   {
@@ -2412,6 +2432,10 @@ exports[`activateMetronome > shall use the correct metronomeFactor for each skil
         17,
       ],
       "modifierName": "Present",
+      "targeting": {
+        "chanceToTargetLowestMembers": 0,
+        "numMonsTargeted": 1,
+      },
     },
   },
   {

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/charge-energy-s-moonlight-effect.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/charge-energy-s-moonlight-effect.test.ts
@@ -56,6 +56,6 @@ describe('ChargeEnergySMoonlightEffect', () => {
     expect(activation.activations[0].self?.regular).toBeGreaterThan(0);
     expect(activation.activations[0].self?.crit).toBe(0);
     expect(activation.activations[0].team?.crit).toBe(teamAmount);
-    expect(activation.activations[0].team?.chanceToTargetLowestMember).toBe(0.5);
+    expect(activation.targeting?.chanceToTargetLowestMembers).toBe(skill.targeting.chanceToTargetLowestMembers);
   });
 });

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/charge-energy-s-moonlight-effect.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/charge-energy-s-moonlight-effect.ts
@@ -27,11 +27,11 @@ export class ChargeEnergySMoonlightEffect implements SkillEffect {
             self: { regular: clampedEnergyRecovered, crit: 0 },
             team: {
               regular: 0,
-              crit: teamAmount,
-              chanceToTargetLowestMember: 0.5
+              crit: teamAmount
             }
           }
-        ]
+        ],
+        targeting: skill.targeting
       };
     }
 

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/cooking-power-up-s-minus-effect.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/cooking-power-up-s-minus-effect.ts
@@ -14,7 +14,6 @@ export class CookingPowerUpSMinusEffect implements SkillEffect {
       ).length === 0
         ? 0
         : skillState.skillAmount(skill.activations.paired);
-    const chanceToTargetLowestMember = skill.activations.paired.targetLowestChance;
 
     return {
       skill,
@@ -27,11 +26,11 @@ export class CookingPowerUpSMinusEffect implements SkillEffect {
           unit: 'energy',
           team: {
             regular: energyAmount,
-            crit: 0,
-            chanceToTargetLowestMember
+            crit: 0
           }
         }
-      ]
+      ],
+      targeting: skill.targeting
     };
   }
 }

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/energizing-cheer-s-effect.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/energizing-cheer-s-effect.test.ts
@@ -2,7 +2,6 @@ import type { MemberState } from '@src/services/simulation-service/team-simulato
 import { EnergizingCheerSEffect } from '@src/services/simulation-service/team-simulator/skill-state/skill-effects/energizing-cheer-s-effect.js';
 import type { SkillState } from '@src/services/simulation-service/team-simulator/skill-state/skill-state.js';
 import { mocks } from '@src/vitest/index.js';
-import { EnergizingCheerS } from 'sleepapi-common';
 import { vimic } from 'vimic';
 import { beforeEach, describe, expect, it } from 'vitest';
 
@@ -19,23 +18,14 @@ describe('EnergizingCheerSEffect', () => {
 
   it('should activate skill and return correct team value', () => {
     const regularEnergyAmount = 20;
-    const chanceToTargetLowest = EnergizingCheerS.activations.energy.targetLowestChance;
     vimic(skillState, 'skillAmount', () => regularEnergyAmount);
 
     const result = energizingCheerSEffect.activate(skillState);
 
-    expect(result).toEqual({
-      skill: EnergizingCheerS,
-      activations: [
-        {
-          unit: 'energy',
-          team: {
-            regular: regularEnergyAmount,
-            crit: 0,
-            chanceToTargetLowestMember: chanceToTargetLowest
-          }
-        }
-      ]
+    expect(result.activations.length).toEqual(1);
+    expect(result.activations[0].team).toEqual({
+      regular: regularEnergyAmount,
+      crit: 0
     });
   });
 

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/energizing-cheer-s-effect.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/energizing-cheer-s-effect.ts
@@ -7,7 +7,6 @@ export class EnergizingCheerSEffect implements SkillEffect {
   activate(skillState: SkillState): SkillActivation {
     const skill = EnergizingCheerS;
     const regularEnergyAmount = skillState.skillAmount(skill.activations.energy);
-    const chanceToTargetLowestMember = EnergizingCheerS.activations.energy.targetLowestChance;
 
     return {
       skill,
@@ -16,11 +15,11 @@ export class EnergizingCheerSEffect implements SkillEffect {
           unit: 'energy',
           team: {
             regular: regularEnergyAmount,
-            crit: 0,
-            chanceToTargetLowestMember
+            crit: 0
           }
         }
-      ]
+      ],
+      targeting: skill.targeting
     };
   }
 }

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/energizing-cheer-s-nuzzle-effect.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/energizing-cheer-s-nuzzle-effect.ts
@@ -8,7 +8,6 @@ export class EnergizingCheerSNuzzleEffect implements SkillEffect {
     const skill = EnergizingCheerSNuzzle;
     const energyAmount = skillState.skillAmount(skill.activations.energy);
     const skillHelpsAmount = skillState.skillAmount(skill.activations.skillHelps);
-    const chanceToTargetLowestMember = EnergizingCheerSNuzzle.activations.energy.targetLowestChance;
 
     return {
       skill,
@@ -17,8 +16,7 @@ export class EnergizingCheerSNuzzleEffect implements SkillEffect {
           unit: 'energy',
           team: {
             regular: energyAmount,
-            crit: 0,
-            chanceToTargetLowestMember
+            crit: 0
           }
         },
         {
@@ -28,7 +26,8 @@ export class EnergizingCheerSNuzzleEffect implements SkillEffect {
             crit: 0
           }
         }
-      ]
+      ],
+      targeting: skill.targeting
     };
   }
 }

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/extra-helpful-s-effect.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/extra-helpful-s-effect.test.ts
@@ -32,12 +32,12 @@ describe('ExtraHelpfulSEffect', () => {
       activations: [
         {
           unit: 'helps',
-          team: { regular: regularAmount / memberState.teamSize, crit: 0 }
+          team: { regular: regularAmount, crit: 0 }
         }
       ],
       targeting: {
         chanceToTargetLowestMembers: 0,
-        numMonsTargeted: 4 // in this commit, the behavior of targeting each mon on the team is preserved
+        numMonsTargeted: 1
       }
     });
   });

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/extra-helpful-s-effect.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/extra-helpful-s-effect.test.ts
@@ -34,7 +34,11 @@ describe('ExtraHelpfulSEffect', () => {
           unit: 'helps',
           team: { regular: regularAmount / memberState.teamSize, crit: 0 }
         }
-      ]
+      ],
+      targeting: {
+        chanceToTargetLowestMembers: 0,
+        numMonsTargeted: 4 // in this commit, the behavior of targeting each mon on the team is preserved
+      }
     });
   });
 
@@ -54,7 +58,11 @@ describe('ExtraHelpfulSEffect', () => {
           unit: 'helps',
           team: { regular: regularAmount, crit: 0 }
         }
-      ]
+      ],
+      targeting: {
+        chanceToTargetLowestMembers: 0,
+        numMonsTargeted: 1
+      }
     });
   });
 
@@ -74,7 +82,11 @@ describe('ExtraHelpfulSEffect', () => {
           unit: 'helps',
           team: { regular: 0, crit: 0 }
         }
-      ]
+      ],
+      targeting: {
+        chanceToTargetLowestMembers: 0,
+        numMonsTargeted: 1
+      }
     });
   });
 });

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/extra-helpful-s-effect.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/extra-helpful-s-effect.ts
@@ -6,7 +6,7 @@ import { ExtraHelpfulS } from 'sleepapi-common';
 export class ExtraHelpfulSEffect implements SkillEffect {
   activate(skillState: SkillState): SkillActivation {
     const skill = ExtraHelpfulS;
-    const regularAmount = skillState.skillAmount(skill.activations.helps) / skillState.memberState.teamSize;
+    const regularAmount = skillState.skillAmount(skill.activations.helps);
 
     return {
       skill,
@@ -19,12 +19,7 @@ export class ExtraHelpfulSEffect implements SkillEffect {
           }
         }
       ],
-      targeting: {
-        chanceToTargetLowestMembers: skill.targeting.chanceToTargetLowestMembers,
-        // in this commit, the behavior of giving all team members 1/N of the helps rather than
-        // giving all the helps to one team member is preserved.
-        numMonsTargeted: skill.targeting.numMonsTargeted * skillState.memberState.teamSize
-      }
+      targeting: skill.targeting
     };
   }
 }

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/extra-helpful-s-effect.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/extra-helpful-s-effect.ts
@@ -18,7 +18,13 @@ export class ExtraHelpfulSEffect implements SkillEffect {
             crit: 0
           }
         }
-      ]
+      ],
+      targeting: {
+        chanceToTargetLowestMembers: skill.targeting.chanceToTargetLowestMembers,
+        // in this commit, the behavior of giving all team members 1/N of the helps rather than
+        // giving all the helps to one team member is preserved.
+        numMonsTargeted: skill.targeting.numMonsTargeted * skillState.memberState.teamSize
+      }
     };
   }
 }

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-state-types.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-state-types.ts
@@ -1,12 +1,11 @@
-import type { Mainskill, MainskillUnit } from 'sleepapi-common';
+import type { Mainskill, MainskillTargeting, MainskillUnit } from 'sleepapi-common';
 
 export interface SelfActivationValue {
   regular: number;
   crit: number;
 }
-export interface TeamActivationValue extends SelfActivationValue {
-  chanceToTargetLowestMember?: number; // optional, if undefined this skill does not randomize between members
-}
+// TODO: Maybe replace both of these types with ActivationValue
+export type TeamActivationValue = SelfActivationValue;
 
 export interface UnitActivation {
   unit: MainskillUnit;
@@ -16,5 +15,6 @@ export interface UnitActivation {
 
 export interface SkillActivation {
   skill: Mainskill;
+  targeting?: MainskillTargeting;
   activations: UnitActivation[];
 }

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-state.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-state.ts
@@ -145,7 +145,7 @@ export class SkillState {
     this.pityProcThreshold = calculatePityProcThreshold(memberState.member.pokemonWithIngredients.pokemon);
   }
 
-  // // TODO: apparently returning early here makes the team sim insanely fast, so skill handling is slower than expected
+  // TODO: apparently returning early here makes the team sim insanely fast, so skill handling is slower than expected
   public attemptSkill(): SkillActivation[] {
     const activations: SkillActivation[] = [];
     this.helpsSinceLastSkillProc += 1;
@@ -186,8 +186,7 @@ export class SkillState {
       skillAmount: (this.regularValue + this.critValue) / iterations,
       skillValue: Object.fromEntries(
         Object.entries(this.skillValue)
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          .filter(([d_, value]) => value.amountToSelf !== 0 || value.amountToTeam !== 0)
+          .filter(([_d, value]) => value.amountToSelf !== 0 || value.amountToTeam !== 0)
           .map(([key, value]) => [
             key,
             {

--- a/backend/src/services/simulation-service/team-simulator/team-simulator.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator.test.ts
@@ -1,4 +1,9 @@
-import type { TeamActivationValue } from '@src/services/simulation-service/team-simulator/skill-state/skill-state-types.js';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type {
+  SkillActivation,
+  TeamActivationValue,
+  UnitActivation
+} from '@src/services/simulation-service/team-simulator/skill-state/skill-state-types.js';
 import { TeamSimulator } from '@src/services/simulation-service/team-simulator/team-simulator.js';
 import { mocks } from '@src/vitest/index.js';
 import type { PokemonWithIngredients, TeamMemberExt, TeamSettingsExt } from 'sleepapi-common';
@@ -391,7 +396,6 @@ describe('recoverMemberEnergy', () => {
       settings: mockSettings,
       members: mockMembers.concat(mockMembers),
       iterations: 1
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any;
 
     const energy: TeamActivationValue = {
@@ -399,9 +403,8 @@ describe('recoverMemberEnergy', () => {
       regular: 50
     };
 
-    simulator.recoverMemberEnergy(energy, simulator.memberStates[0]);
+    simulator.recoverMemberEnergy(energy, simulator.memberStates[0], simulator.memberStates);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     simulator.memberStates.forEach((member: any) => {
       expect(member.energy).toBe(50);
     });
@@ -412,19 +415,164 @@ describe('recoverMemberEnergy', () => {
       settings: mockSettings,
       members: mockMembers.concat(mockMembers),
       iterations: 1
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any;
     simulator.memberStates[0].recoverEnergy(100, simulator.memberStates[0]);
 
     const energy: TeamActivationValue = {
       crit: 0,
-      regular: 50,
-      chanceToTargetLowestMember: 1
+      regular: 50
     };
 
-    simulator.recoverMemberEnergy(energy, simulator.memberStates[0]);
+    simulator.recoverMemberEnergy(energy, simulator.memberStates[0], [simulator.memberStates[1]]);
     expect(simulator.memberStates).toHaveLength(2);
     expect(simulator.memberStates[0].energy).toBe(100);
     expect(simulator.memberStates[1].energy).toBe(50);
+  });
+
+  it("shall recover some members' energy", () => {
+    const simulator = new TeamSimulator({
+      settings: mockSettings,
+      members: mockMembers.concat(mockMembers).concat(mockMembers),
+      iterations: 1
+    }) as any;
+
+    const energy: TeamActivationValue = {
+      crit: 0,
+      regular: 50
+    };
+
+    simulator.recoverMemberEnergy(energy, simulator.memberStates[0], [
+      simulator.memberStates[1],
+      simulator.memberStates[2]
+    ]);
+    expect(simulator.memberStates).toHaveLength(3);
+    expect(simulator.memberStates[0].energy).toBe(0);
+    expect(simulator.memberStates[1].energy).toBe(50);
+    expect(simulator.memberStates[2].energy).toBe(50);
+  });
+});
+
+describe('processTeamEnergyActivation', () => {
+  it('shall heal all members', () => {
+    const simulator = new TeamSimulator({
+      settings: mockSettings,
+      members: mockMembers.concat(mockMembers).concat(mockMembers),
+      iterations: 1
+    }) as any;
+
+    simulator.memberStates[0].recoverEnergy(50, simulator.memberStates[0]);
+    simulator.memberStates[1].recoverEnergy(30, simulator.memberStates[1]);
+    simulator.memberStates[2].recoverEnergy(10, simulator.memberStates[2]);
+
+    const energyActivation: UnitActivation = {
+      unit: 'energy',
+      team: {
+        crit: 0,
+        regular: 30
+      }
+    };
+
+    simulator.processTeamEnergyActivation(energyActivation, simulator.memberStates[0], simulator.memberStates);
+    expect(simulator.memberStates).toHaveLength(3);
+    expect(simulator.memberStates[0].energy).toBe(80);
+    expect(simulator.memberStates[1].energy).toBe(60);
+    expect(simulator.memberStates[2].energy).toBe(40);
+  });
+
+  it('shall heal some members', () => {
+    const simulator = new TeamSimulator({
+      settings: mockSettings,
+      members: mockMembers.concat(mockMembers).concat(mockMembers),
+      iterations: 1
+    }) as any;
+
+    simulator.memberStates[0].recoverEnergy(50, simulator.memberStates[0]);
+    simulator.memberStates[1].recoverEnergy(30, simulator.memberStates[1]);
+    simulator.memberStates[2].recoverEnergy(10, simulator.memberStates[2]);
+
+    const energyActivation: UnitActivation = {
+      unit: 'energy',
+      team: {
+        crit: 0,
+        regular: 30
+      }
+    };
+
+    simulator.processTeamEnergyActivation(energyActivation, simulator.memberStates[0], [
+      simulator.memberStates[1],
+      simulator.memberStates[2]
+    ]);
+    expect(simulator.memberStates).toHaveLength(3);
+    expect(simulator.memberStates[0].energy).toBe(50);
+    expect(simulator.memberStates[1].energy).toBe(60);
+    expect(simulator.memberStates[2].energy).toBe(40);
+  });
+});
+
+describe('maybeActivateTeamSkill (energy)', () => {
+  it('shall heal all members without chanceToTargetLowest', () => {
+    const simulator = new TeamSimulator({
+      settings: mockSettings,
+      members: mockMembers.concat(mockMembers).concat(mockMembers),
+      iterations: 1
+    }) as any;
+
+    simulator.memberStates[0].recoverEnergy(50, simulator.memberStates[0]);
+    simulator.memberStates[1].recoverEnergy(30, simulator.memberStates[1]);
+    simulator.memberStates[2].recoverEnergy(10, simulator.memberStates[2]);
+
+    const energyActivation: SkillActivation = {
+      skill: commonMocks.mockMainskill,
+      activations: [
+        {
+          unit: 'energy',
+          team: {
+            crit: 0,
+            regular: 30
+          }
+        }
+      ]
+    };
+
+    simulator.maybeActivateTeamSkill(energyActivation, simulator.memberStates[0]);
+    expect(simulator.memberStates).toHaveLength(3);
+    expect(simulator.memberStates[0].energy).toBe(80);
+    expect(simulator.memberStates[1].energy).toBe(60);
+    expect(simulator.memberStates[2].energy).toBe(40);
+  });
+
+  it('shall heal lowest members with chanceToTargetLowest', () => {
+    const simulator = new TeamSimulator({
+      settings: mockSettings,
+      members: mockMembers.concat(mockMembers).concat(mockMembers),
+      iterations: 1
+    }) as any;
+
+    simulator.memberStates[0].recoverEnergy(50, simulator.memberStates[0]);
+    simulator.memberStates[1].recoverEnergy(30, simulator.memberStates[1]);
+    simulator.memberStates[2].recoverEnergy(10, simulator.memberStates[2]);
+    expect(simulator.memberStates).toHaveLength(3);
+    expect(simulator.memberStates[0].energy).toBe(50);
+    expect(simulator.memberStates[1].energy).toBe(30);
+    expect(simulator.memberStates[2].energy).toBe(10);
+
+    const energyActivation: SkillActivation = {
+      skill: commonMocks.mockMainskill,
+      targeting: { chanceToTargetLowestMembers: 1, numMonsTargeted: 2 },
+      activations: [
+        {
+          unit: 'energy',
+          team: {
+            crit: 0,
+            regular: 30
+          }
+        }
+      ]
+    };
+
+    simulator.maybeActivateTeamSkill(energyActivation, simulator.memberStates[0]);
+    expect(simulator.memberStates[0].energy).toBe(50);
+    expect(simulator.memberStates[1].energy).toBe(60);
+    expect(simulator.memberStates[2].energy).toBe(40);
   });
 });

--- a/backend/src/services/simulation-service/team-simulator/team-simulator.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator.ts
@@ -18,11 +18,13 @@ import type { CookingState } from '@src/services/simulation-service/team-simulat
 import { MemberState } from '@src/services/simulation-service/team-simulator/member-state/member-state.js';
 import type {
   SkillActivation,
-  TeamActivationValue
+  TeamActivationValue,
+  UnitActivation
 } from '@src/services/simulation-service/team-simulator/skill-state/skill-state-types.js';
 import { TeamSimulatorUtils } from '@src/services/simulation-service/team-simulator/team-simulator-utils.js';
 import type { PreGeneratedRandom } from '@src/utils/random-utils/pre-generated-random.js';
 import { createPreGeneratedRandom } from '@src/utils/random-utils/pre-generated-random.js';
+import type { MainskillTargeting } from 'sleepapi-common';
 import {
   commonMocks,
   event as expertModeGreengrassEvent,
@@ -211,58 +213,131 @@ export class TeamSimulator {
     }
   }
 
-  // TODO: won't change things now, but this should probably find all help/energy units rather than the first (which find does)
   private maybeActivateTeamSkill(result: SkillActivation, invoker: MemberState, recursionDepth: number = 0) {
-    const helpsActivation = result.activations.find((activation) => activation.unit === 'helps' && activation.team);
-    if (helpsActivation?.team) {
-      for (const mem of this.memberStatesWithoutFillers) {
-        mem.addHelpsFromSkill(helpsActivation.team, invoker);
-        invoker.addSkillValue(helpsActivation.team);
+    const teamActivations = result.activations.filter((activation) => activation.team);
+
+    if (result.targeting === undefined) {
+      // The team activations effect the whole team, like Energy For Everyone and Helper Boost
+      for (const activation of teamActivations) {
+        this.processFullTeamActivation(activation, invoker, recursionDepth);
+      }
+    } else {
+      // The team activations target certain members, like Energizing Cheer and Extra Helpful
+
+      // Currently, all skills that do multiple things to targeted mons target the same mons for each of these things.
+      // E.g. Nuzzle restores energy to the same mon that gets the bonus skill helps
+      // That's why one method takes all of them, whereas the full team activations can be handled independently.
+      this.processTargetedActivation(teamActivations, result.targeting, invoker, recursionDepth);
+    }
+  }
+
+  private processFullTeamActivation(activation: UnitActivation, invoker: MemberState, recursionDepth: number) {
+    if (activation.team === undefined) {
+      return;
+    }
+    if (activation.unit === 'helps') {
+      this.processTeamHelpActivation(activation, invoker, this.memberStatesWithoutFillers);
+    }
+    if (activation.unit === 'skill helps') {
+      this.processTeamSkillHelpActivation(activation, invoker, this.memberStatesWithoutFillers, recursionDepth);
+    }
+    if (activation.unit === 'energy') {
+      this.processTeamEnergyActivation(activation, invoker, this.memberStatesWithoutFillers);
+    }
+  }
+
+  private processTargetedActivation(
+    activations: UnitActivation[],
+    targeting: MainskillTargeting,
+    invoker: MemberState,
+    recursionDepth: number
+  ) {
+    const { chanceToTargetLowestMembers, numMonsTargeted } = targeting;
+    const teamActivations = activations.filter((activation) => activation.team);
+    if (teamActivations.length === 0) {
+      return;
+    }
+    const targetGroup: MemberState[] = this.findTargetGroup(numMonsTargeted, chanceToTargetLowestMembers);
+
+    for (const activation of teamActivations) {
+      if (activation.unit === 'helps') {
+        this.processTeamHelpActivation(activation, invoker, targetGroup);
+      }
+      if (activation.unit === 'skill helps') {
+        this.processTeamSkillHelpActivation(activation, invoker, targetGroup, recursionDepth);
+      }
+      if (activation.unit === 'energy') {
+        this.processTeamEnergyActivation(activation, invoker, targetGroup);
       }
     }
+  }
 
-    let membersHelped: MemberState[] = [];
+  private findTargetGroup(numMonsTargeted?: number, chanceToTargetLowestMembers?: number): MemberState[] {
+    const copyOfMemberStates = this.memberStatesWithoutFillers.slice();
+    const shuffledMembers = copyOfMemberStates
+      .map((member) => {
+        return {
+          member,
+          randVal: this.rng()
+        };
+      })
+      .sort((a, b) => a.randVal - b.randVal)
+      .map((member) => member.member);
+    const sortedMembers = shuffledMembers.sort((a, b) => a.energy - b.energy);
 
-    const energyActivation = result.activations.find((activation) => activation.unit === 'energy' && activation.team);
-    if (energyActivation?.team) {
-      const recovered = this.recoverMemberEnergy(energyActivation.team, invoker);
-      invoker.wasteEnergy(recovered.regular.wastedEnergy + recovered.crit.wastedEnergy);
-      invoker.addSkillValue({ regular: recovered.regular.skillValue, crit: recovered.crit.skillValue });
-      membersHelped = recovered.targetGroup;
+    const useLowestMembers = chanceToTargetLowestMembers !== undefined && this.rng() < chanceToTargetLowestMembers;
+    return (useLowestMembers ? shuffledMembers : sortedMembers).slice(0, numMonsTargeted ?? 5);
+  }
+
+  private processTeamHelpActivation(activation: UnitActivation, invoker: MemberState, membersHelped: MemberState[]) {
+    if (activation.unit !== 'helps' || activation.team === undefined) {
+      return;
     }
+    for (const member of membersHelped) {
+      member.addHelpsFromSkill(activation.team, invoker);
+      invoker.addSkillValue(activation.team);
+    }
+  }
 
-    const skillHelpsActivation = result.activations.find(
-      (activation) => activation.unit === 'skill helps' && activation.team
-    );
-    if (skillHelpsActivation?.team) {
-      for (const mem of membersHelped) {
-        const bonusActivations: SkillActivation[] = mem.addSkillHelps(skillHelpsActivation.team);
-        invoker.addSkillValue({ regular: bonusActivations.length, crit: 0 });
-        if (recursionDepth < 10) {
-          // In theory, a team of all Togedemaru could keep giving each other bonus activations.
-          // The odds are very slim, so I'm making the simulation slightly less accurate in order to avoid potential infinite recursion.
-          for (const bonusActivation of bonusActivations) {
-            this.maybeActivateTeamSkill(bonusActivation, mem, recursionDepth + 1);
-          }
+  private processTeamSkillHelpActivation(
+    activation: UnitActivation,
+    invoker: MemberState,
+    membersHelped: MemberState[],
+    recursionDepth: number
+  ) {
+    if (activation.unit !== 'skill helps' || activation.team === undefined) {
+      return;
+    }
+    for (const member of membersHelped) {
+      const bonusActivations: SkillActivation[] = member.addSkillHelps(activation.team);
+      invoker.addSkillValue({ regular: bonusActivations.length, crit: 0 });
+      if (recursionDepth < 10) {
+        // In theory, a team of all Togedemaru could keep giving each other bonus activations.
+        // The odds are very slim, so I'm making the simulation slightly less accurate in order to avoid potential infinite recursion.
+        for (const bonusActivation of bonusActivations) {
+          this.maybeActivateTeamSkill(bonusActivation, member, recursionDepth + 1);
         }
       }
     }
   }
 
-  private recoverMemberEnergy(activation: TeamActivationValue, invoker: MemberState) {
-    const { chanceToTargetLowestMember, crit, regular } = activation;
+  private processTeamEnergyActivation(activation: UnitActivation, invoker: MemberState, membersHelped: MemberState[]) {
+    if (activation.unit !== 'energy' || activation.team === undefined) {
+      return;
+    }
+    const recovered = this.recoverMemberEnergy(activation.team, invoker, membersHelped);
+    invoker.wasteEnergy(recovered.regular.wastedEnergy + recovered.crit.wastedEnergy);
+    invoker.addSkillValue({ regular: recovered.regular.skillValue, crit: recovered.crit.skillValue });
+  }
+
+  private recoverMemberEnergy(activation: TeamActivationValue, invoker: MemberState, targetGroup: MemberState[]) {
+    const { crit, regular } = activation;
     let valueRegular = 0;
     let valueCrit = 0;
     let wastedRegular = 0;
     let wastedCrit = 0;
-    let targetGroup: MemberState[] = [];
 
     if (regular + crit > 0) {
-      targetGroup =
-        chanceToTargetLowestMember !== undefined
-          ? this.energyTargetMember(chanceToTargetLowestMember)
-          : this.memberStates;
-
       for (const mem of targetGroup) {
         const { recovered: regularRecovered, wasted: regularWasted } = mem.recoverEnergy(regular, invoker);
         const { recovered: critRecovered, wasted: critWasted } = mem.recoverEnergy(crit, invoker);
@@ -278,20 +353,6 @@ export class TeamSimulator {
       crit: { wastedEnergy: wastedCrit, skillValue: valueCrit },
       targetGroup
     };
-  }
-
-  /**
-   * @returns array of size 1 containing the randomized member to target
-   */
-  private energyTargetMember(chanceTargetLowest: number): MemberState[] {
-    const sortedMembers = [...this.memberStates].sort((a, b) => a.energy - b.energy);
-    const lowestEnergy = sortedMembers[0]?.energy ?? 0;
-
-    const lowestEnergyMembers = sortedMembers.filter((mem) => mem.energy === lowestEnergy);
-    const allMembers = this.memberStates;
-
-    const targetGroup = this.rng() < chanceTargetLowest ? lowestEnergyMembers : allMembers;
-    return [this.rng.randomElement(targetGroup)].filter((member): member is MemberState => member !== undefined);
   }
 
   private collectInventory() {

--- a/backend/src/utils/event-utils/event-utils.test.ts
+++ b/backend/src/utils/event-utils/event-utils.test.ts
@@ -99,6 +99,10 @@ describe('getExtraHelpfulEvents', () => {
               ],
               "image": "helps",
               "name": "Extra Helpful S",
+              "targeting": {
+                "chanceToTargetLowestMembers": 0,
+                "numMonsTargeted": 1,
+              },
             },
           },
           "time": {
@@ -166,6 +170,10 @@ describe('getExtraHelpfulEvents', () => {
               ],
               "image": "helps",
               "name": "Extra Helpful S",
+              "targeting": {
+                "chanceToTargetLowestMembers": 0,
+                "numMonsTargeted": 1,
+              },
             },
           },
           "time": {

--- a/common/src/types/mainskill/index.ts
+++ b/common/src/types/mainskill/index.ts
@@ -1,3 +1,4 @@
 export * from './mainskill';
+export * from './mainskill-targeting';
 export * from './mainskill-unit';
 export * from './mainskills';

--- a/common/src/types/mainskill/mainskill-targeting.ts
+++ b/common/src/types/mainskill/mainskill-targeting.ts
@@ -1,0 +1,4 @@
+export type MainskillTargeting = {
+  numMonsTargeted: number;
+  chanceToTargetLowestMembers: number;
+};

--- a/common/src/types/mainskill/mainskills/charge-energy-s-moonlight.ts
+++ b/common/src/types/mainskill/mainskills/charge-energy-s-moonlight.ts
@@ -1,5 +1,6 @@
 import type { ActivationsType, AmountParams } from '../mainskill';
 import { ModifiedMainskill } from '../mainskill';
+import type { MainskillTargeting } from '../mainskill-targeting';
 import { ChargeEnergyS } from './charge-energy-s';
 
 export const ChargeEnergySMoonlight = new (class extends ModifiedMainskill {
@@ -11,6 +12,11 @@ export const ChargeEnergySMoonlight = new (class extends ModifiedMainskill {
   description = (params: AmountParams) =>
     `Restores ${this.energyAmounts[params.skillLevel - 1]} Energy to the user. Has a chance of restoring ${this.critAmounts[params.skillLevel - 1]} energy to another Pokémon.`;
   RP = [560, 797, 1099, 1516, 2094, 2892];
+
+  targeting: MainskillTargeting = {
+    numMonsTargeted: 1,
+    chanceToTargetLowestMembers: 0.5
+  };
 
   activations: ActivationsType = {
     energy: {

--- a/common/src/types/mainskill/mainskills/cooking-power-up-s-minus.ts
+++ b/common/src/types/mainskill/mainskills/cooking-power-up-s-minus.ts
@@ -1,5 +1,6 @@
 import type { ActivationsType, AmountParams } from '../mainskill';
 import { ModifiedMainskill } from '../mainskill';
+import type { MainskillTargeting } from '../mainskill-targeting';
 import { CookingPowerUpS } from './cooking-power-up-s';
 
 export const CookingPowerUpSMinus = new (class extends ModifiedMainskill {
@@ -14,6 +15,11 @@ export const CookingPowerUpSMinus = new (class extends ModifiedMainskill {
   fullDescription = (params: AmountParams) =>
     `Gives your cooking pot room for ${this.potSizeAmounts[params.skillLevel - 1]} more ingredients next time you cook. If there's one or more other Pokémon on the team with the Plus or Minus main skills, also restores ${this.energyAmounts[params.skillLevel - 1]} Energy to one random Pokémon on your team.`;
 
+  targeting: MainskillTargeting = {
+    numMonsTargeted: 1,
+    chanceToTargetLowestMembers: 0.5
+  };
+
   activations: ActivationsType = {
     solo: {
       unit: 'pot size',
@@ -21,8 +27,7 @@ export const CookingPowerUpSMinus = new (class extends ModifiedMainskill {
     },
     paired: {
       unit: 'energy',
-      amount: this.leveledAmount(this.energyAmounts),
-      targetLowestChance: 0.5 // unverified
+      amount: this.leveledAmount(this.energyAmounts)
     }
   };
 })(true);

--- a/common/src/types/mainskill/mainskills/energizing-cheer-s-nuzzle.test.ts
+++ b/common/src/types/mainskill/mainskills/energizing-cheer-s-nuzzle.test.ts
@@ -23,6 +23,6 @@ describe('EnergizingCheerSNuzzle', () => {
   });
 
   it('should have target lowest chance property', () => {
-    expect(EnergizingCheerSNuzzle.activations.energy.targetLowestChance).toBe(0.5);
+    expect(EnergizingCheerSNuzzle.targeting.chanceToTargetLowestMembers).toBe(0.5);
   });
 });

--- a/common/src/types/mainskill/mainskills/energizing-cheer-s-nuzzle.ts
+++ b/common/src/types/mainskill/mainskills/energizing-cheer-s-nuzzle.ts
@@ -1,5 +1,6 @@
 import type { ActivationsType, AmountParams } from '../mainskill';
 import { ModifiedMainskill } from '../mainskill';
+import type { MainskillTargeting } from '../mainskill-targeting';
 import { EnergizingCheerS } from './energizing-cheer-s';
 
 export const EnergizingCheerSNuzzle = new (class extends ModifiedMainskill {
@@ -13,11 +14,15 @@ export const EnergizingCheerSNuzzle = new (class extends ModifiedMainskill {
   description = (params: AmountParams) =>
     `Restores ${this.energyAmounts[params.skillLevel - 1]} Energy to one random Pokémon on your team. If you're lucky, that Pokémon will also gain a main skill activation bonus.`;
 
+  targeting: MainskillTargeting = {
+    numMonsTargeted: 1,
+    chanceToTargetLowestMembers: 0.5
+  };
+
   activations: ActivationsType = {
     energy: {
       unit: 'energy',
-      amount: this.leveledAmount(this.energyAmounts),
-      targetLowestChance: 0.5 // TODO: Research this value
+      amount: this.leveledAmount(this.energyAmounts)
     },
     skillHelps: {
       unit: 'skill helps',

--- a/common/src/types/mainskill/mainskills/energizing-cheer-s.test.ts
+++ b/common/src/types/mainskill/mainskills/energizing-cheer-s.test.ts
@@ -27,7 +27,7 @@ describe('EnergizingCheerS', () => {
   });
 
   it('should have target lowest chance property', () => {
-    expect(EnergizingCheerS.activations.energy.targetLowestChance).toBe(0.5);
+    expect(EnergizingCheerS.targeting.chanceToTargetLowestMembers).toBe(0.5);
   });
 
   it('should have energy unit only', () => {

--- a/common/src/types/mainskill/mainskills/energizing-cheer-s.ts
+++ b/common/src/types/mainskill/mainskills/energizing-cheer-s.ts
@@ -1,5 +1,6 @@
 import type { ActivationsType, AmountParams } from '../mainskill';
 import { Mainskill } from '../mainskill';
+import type { MainskillTargeting } from '../mainskill-targeting';
 
 export const EnergizingCheerS = new (class extends Mainskill {
   name = 'Energizing Cheer S';
@@ -8,11 +9,16 @@ export const EnergizingCheerS = new (class extends Mainskill {
   image = 'energy';
   description = (params: AmountParams) =>
     `Restores ${this.energyAmounts[params.skillLevel - 1]} Energy to one random Pokémon on your team.`;
+
+  targeting: MainskillTargeting = {
+    numMonsTargeted: 1,
+    chanceToTargetLowestMembers: 0.5
+  };
+
   activations: ActivationsType = {
     energy: {
       unit: 'energy',
-      amount: this.leveledAmount(this.energyAmounts),
-      targetLowestChance: 0.5 // TODO: this should be bumped
+      amount: this.leveledAmount(this.energyAmounts)
     }
   };
 })(true);

--- a/common/src/types/mainskill/mainskills/extra-helpful-s.ts
+++ b/common/src/types/mainskill/mainskills/extra-helpful-s.ts
@@ -1,5 +1,6 @@
 import type { ActivationsType, AmountParams } from '../mainskill';
 import { Mainskill } from '../mainskill';
+import type { MainskillTargeting } from '../mainskill-targeting';
 
 export const ExtraHelpfulS = new (class extends Mainskill {
   name = 'Extra Helpful S';
@@ -8,6 +9,12 @@ export const ExtraHelpfulS = new (class extends Mainskill {
   image = 'helps';
   description = (params: AmountParams) =>
     `Instantly gets you ×${this.helpAmounts[params.skillLevel - 1]} the usual help from a helper Pokémon.`;
+
+  targeting: MainskillTargeting = {
+    numMonsTargeted: 1,
+    chanceToTargetLowestMembers: 0
+  };
+
   activations: ActivationsType = {
     helps: {
       unit: 'helps',

--- a/common/src/types/mainskill/mainskills/present-ingredient-magnet-s.ts
+++ b/common/src/types/mainskill/mainskills/present-ingredient-magnet-s.ts
@@ -1,5 +1,6 @@
 import type { ActivationsType, AmountParams } from '../mainskill';
 import { ModifiedMainskill } from '../mainskill';
+import type { MainskillTargeting } from '../mainskill-targeting';
 import { IngredientMagnetS } from './ingredient-magnet-s';
 
 export const PresentIngredientMagnetS = new (class extends ModifiedMainskill {
@@ -12,6 +13,11 @@ export const PresentIngredientMagnetS = new (class extends ModifiedMainskill {
   image = 'ingredients';
   description = (params: AmountParams) =>
     `Gets you ${this.ingredientAmounts[params.skillLevel - 1]} ingredients chosen at random. Sometimes gets an additional ${this.candyAmount} candy for one Pokémon on your team.`;
+
+  targeting: MainskillTargeting = {
+    numMonsTargeted: 1,
+    chanceToTargetLowestMembers: 0
+  };
 
   activations: ActivationsType = {
     ingredients: {

--- a/common/src/types/pokemon/__snapshots__/pokemon.test.ts.snap
+++ b/common/src/types/pokemon/__snapshots__/pokemon.test.ts.snap
@@ -784,6 +784,10 @@ exports[`COMPLETE_POKEDEX > shall not change ARCANINE unexpectedly 1`] = `
     ],
     "image": "helps",
     "name": "Extra Helpful S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 4.9,
   "specialty": "skill",
@@ -6289,7 +6293,6 @@ exports[`COMPLETE_POKEDEX > shall not change COMFEY unexpectedly 1`] = `
     "activations": {
       "energy": {
         "amount": [Function],
-        "targetLowestChance": 0.5,
         "unit": "energy",
       },
     },
@@ -6304,6 +6307,10 @@ exports[`COMPLETE_POKEDEX > shall not change COMFEY unexpectedly 1`] = `
     ],
     "image": "energy",
     "name": "Energizing Cheer S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 3.5,
   "specialty": "ingredient",
@@ -8024,6 +8031,10 @@ exports[`COMPLETE_POKEDEX > shall not change DELIBIRD unexpectedly 1`] = `
       17,
     ],
     "modifierName": "Present",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 3,
   "specialty": "ingredient",
@@ -11459,6 +11470,10 @@ exports[`COMPLETE_POKEDEX > shall not change GALLADE unexpectedly 1`] = `
     ],
     "image": "helps",
     "name": "Extra Helpful S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 5.4,
   "specialty": "skill",
@@ -13084,6 +13099,10 @@ exports[`COMPLETE_POKEDEX > shall not change GROWLITHE unexpectedly 1`] = `
     ],
     "image": "helps",
     "name": "Extra Helpful S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 5,
   "specialty": "skill",
@@ -14636,6 +14655,10 @@ exports[`COMPLETE_POKEDEX > shall not change JOLTEON unexpectedly 1`] = `
     ],
     "image": "helps",
     "name": "Extra Helpful S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 3.9,
   "specialty": "skill",
@@ -15196,7 +15219,6 @@ exports[`COMPLETE_POKEDEX > shall not change LEAFEON unexpectedly 1`] = `
     "activations": {
       "energy": {
         "amount": [Function],
-        "targetLowestChance": 0.5,
         "unit": "energy",
       },
     },
@@ -15211,6 +15233,10 @@ exports[`COMPLETE_POKEDEX > shall not change LEAFEON unexpectedly 1`] = `
     ],
     "image": "energy",
     "name": "Energizing Cheer S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 6.9,
   "specialty": "skill",
@@ -17681,7 +17707,6 @@ exports[`COMPLETE_POKEDEX > shall not change MINUN unexpectedly 1`] = `
     "activations": {
       "paired": {
         "amount": [Function],
-        "targetLowestChance": 0.5,
         "unit": "energy",
       },
       "solo": {
@@ -17740,6 +17765,10 @@ exports[`COMPLETE_POKEDEX > shall not change MINUN unexpectedly 1`] = `
       20,
       24,
     ],
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 4.9,
   "specialty": "skill",
@@ -18932,7 +18961,6 @@ exports[`COMPLETE_POKEDEX > shall not change NINETALES unexpectedly 1`] = `
     "activations": {
       "energy": {
         "amount": [Function],
-        "targetLowestChance": 0.5,
         "unit": "energy",
       },
     },
@@ -18947,6 +18975,10 @@ exports[`COMPLETE_POKEDEX > shall not change NINETALES unexpectedly 1`] = `
     ],
     "image": "energy",
     "name": "Energizing Cheer S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 2.9,
   "specialty": "berry",
@@ -19062,6 +19094,10 @@ exports[`COMPLETE_POKEDEX > shall not change NINETALES_ALOLAN unexpectedly 1`] =
     ],
     "image": "helps",
     "name": "Extra Helpful S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 2.8,
   "specialty": "berry",
@@ -24621,7 +24657,6 @@ exports[`COMPLETE_POKEDEX > shall not change SLOWBRO unexpectedly 1`] = `
     "activations": {
       "energy": {
         "amount": [Function],
-        "targetLowestChance": 0.5,
         "unit": "energy",
       },
     },
@@ -24636,6 +24671,10 @@ exports[`COMPLETE_POKEDEX > shall not change SLOWBRO unexpectedly 1`] = `
     ],
     "image": "energy",
     "name": "Energizing Cheer S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 8,
   "specialty": "skill",
@@ -24735,7 +24774,6 @@ exports[`COMPLETE_POKEDEX > shall not change SLOWKING unexpectedly 1`] = `
     "activations": {
       "energy": {
         "amount": [Function],
-        "targetLowestChance": 0.5,
         "unit": "energy",
       },
     },
@@ -24750,6 +24788,10 @@ exports[`COMPLETE_POKEDEX > shall not change SLOWKING unexpectedly 1`] = `
     ],
     "image": "energy",
     "name": "Energizing Cheer S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 8.7,
   "specialty": "skill",
@@ -24852,7 +24894,6 @@ exports[`COMPLETE_POKEDEX > shall not change SLOWPOKE unexpectedly 1`] = `
     "activations": {
       "energy": {
         "amount": [Function],
-        "targetLowestChance": 0.5,
         "unit": "energy",
       },
     },
@@ -24867,6 +24908,10 @@ exports[`COMPLETE_POKEDEX > shall not change SLOWPOKE unexpectedly 1`] = `
     ],
     "image": "energy",
     "name": "Energizing Cheer S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 7.8,
   "specialty": "skill",
@@ -25444,6 +25489,10 @@ exports[`COMPLETE_POKEDEX > shall not change SPIRITOMB unexpectedly 1`] = `
     ],
     "image": "helps",
     "name": "Extra Helpful S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 3.6,
   "specialty": "ingredient",
@@ -26737,7 +26786,6 @@ exports[`COMPLETE_POKEDEX > shall not change TOGEDEMARU unexpectedly 1`] = `
     "activations": {
       "energy": {
         "amount": [Function],
-        "targetLowestChance": 0.5,
         "unit": "energy",
       },
       "skillHelps": {
@@ -26757,7 +26805,6 @@ exports[`COMPLETE_POKEDEX > shall not change TOGEDEMARU unexpectedly 1`] = `
       "activations": {
         "energy": {
           "amount": [Function],
-          "targetLowestChance": 0.5,
           "unit": "energy",
         },
       },
@@ -26772,6 +26819,10 @@ exports[`COMPLETE_POKEDEX > shall not change TOGEDEMARU unexpectedly 1`] = `
       ],
       "image": "energy",
       "name": "Energizing Cheer S",
+      "targeting": {
+        "chanceToTargetLowestMembers": 0.5,
+        "numMonsTargeted": 1,
+      },
     },
     "description": [Function],
     "energyAmounts": [
@@ -26792,6 +26843,10 @@ exports[`COMPLETE_POKEDEX > shall not change TOGEDEMARU unexpectedly 1`] = `
       5,
       6,
     ],
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 5.4,
   "specialty": "skill",
@@ -30137,7 +30192,6 @@ exports[`COMPLETE_POKEDEX > shall not change TOXTRICITY_LOW_KEY unexpectedly 1`]
     "activations": {
       "paired": {
         "amount": [Function],
-        "targetLowestChance": 0.5,
         "unit": "energy",
       },
       "solo": {
@@ -30196,6 +30250,10 @@ exports[`COMPLETE_POKEDEX > shall not change TOXTRICITY_LOW_KEY unexpectedly 1`]
       20,
       24,
     ],
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 6.4,
   "specialty": "skill",
@@ -30815,6 +30873,10 @@ exports[`COMPLETE_POKEDEX > shall not change UMBREON unexpectedly 1`] = `
     ],
     "image": "energy",
     "modifierName": "Moonlight",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 10.1,
   "specialty": "skill",
@@ -31608,7 +31670,6 @@ exports[`COMPLETE_POKEDEX > shall not change VULPIX unexpectedly 1`] = `
     "activations": {
       "energy": {
         "amount": [Function],
-        "targetLowestChance": 0.5,
         "unit": "energy",
       },
     },
@@ -31623,6 +31684,10 @@ exports[`COMPLETE_POKEDEX > shall not change VULPIX unexpectedly 1`] = `
     ],
     "image": "energy",
     "name": "Energizing Cheer S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 3.2,
   "specialty": "berry",
@@ -31740,6 +31805,10 @@ exports[`COMPLETE_POKEDEX > shall not change VULPIX_ALOLAN unexpectedly 1`] = `
     ],
     "image": "helps",
     "name": "Extra Helpful S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 2.8,
   "specialty": "berry",
@@ -32412,7 +32481,6 @@ exports[`COMPLETE_POKEDEX > shall not change WOBBUFFET unexpectedly 1`] = `
     "activations": {
       "energy": {
         "amount": [Function],
-        "targetLowestChance": 0.5,
         "unit": "energy",
       },
     },
@@ -32427,6 +32495,10 @@ exports[`COMPLETE_POKEDEX > shall not change WOBBUFFET unexpectedly 1`] = `
     ],
     "image": "energy",
     "name": "Energizing Cheer S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 8.2,
   "specialty": "skill",
@@ -32758,7 +32830,6 @@ exports[`COMPLETE_POKEDEX > shall not change WYNAUT unexpectedly 1`] = `
     "activations": {
       "energy": {
         "amount": [Function],
-        "targetLowestChance": 0.5,
         "unit": "energy",
       },
     },
@@ -32773,6 +32844,10 @@ exports[`COMPLETE_POKEDEX > shall not change WYNAUT unexpectedly 1`] = `
     ],
     "image": "energy",
     "name": "Energizing Cheer S",
+    "targeting": {
+      "chanceToTargetLowestMembers": 0.5,
+      "numMonsTargeted": 1,
+    },
   },
   "skillPercentage": 6.9,
   "specialty": "skill",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,7 +63,7 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.8.1",
-        "uuid": "~13.0.0"
+        "uuid": "~14.0.0"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.3",


### PR DESCRIPTION
Previously, energy skills targeted 1 or 5 members based on whether a `chanceToTargetLowestMembers` field was defined. And Nuzzle's extra skill activation rolls affected any mons that were healed by the same skill, which would not have worked if we gained a new skill that had the same skill activation effect but didn't restore energy.

Add fields to `SkillActivation` to handle each of these, and remove `chanceToTargetLowestMembers` from `UnitActivation`. At least so far, every skill that does multiple things to team members does the same things to each member it affects.