### PR TITLE
test(common): run all tests with test-watch

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -19,7 +19,7 @@
     "build-rollup": "rollup --config rollup.config.mjs",
     "build-watch": "npm run clean && npm run build-rollup -- --watch",
     "test": "vitest --run --coverage",
-    "test-watch": "vitest --changed",
+    "test-watch": "vitest --watch",
     "type-watch": "bun x tsc --noEmit --watch"
   },
   "devDependencies": {


### PR DESCRIPTION
The common package tests only "changed" tests with `npm run test-watch`. All other packages run all tests with this command.

Personally, I'm often running tests on empty commits or commits with very few changes, because of how jujutsu encourages development. I can't rely on git to know which files I'm trying to test, so I always rerun all tests after it finishes.

Our common unit tests are very quick, so running all of them probably won't be a big issue.