### PR TITLE
fix: cleanup skillValue in compare-strength.vue

### DIFF
--- a/frontend/src/components/compare/compare-strength.test.ts
+++ b/frontend/src/components/compare/compare-strength.test.ts
@@ -7,6 +7,7 @@ import { mount } from '@vue/test-utils'
 import {
   AVERAGE_WEEKLY_CRIT_MULTIPLIER,
   MAX_RECIPE_LEVEL,
+  MathUtils,
   getMaxIngredientBonus,
   recipeLevelBonus,
   type MemberProduction,
@@ -144,9 +145,11 @@ describe('CompareStrength', () => {
     expect(ingredientPower).toContain(lowestIngredientValue.toString())
 
     // Check skill value (cell displays sum of skillValue unit amounts * factor)
-    const displayedSkillValue =
+    const displayedSkillValue = MathUtils.round(
       (mockMemberProduction.skillValue.strength.amountToSelf + mockMemberProduction.skillValue.strength.amountToTeam) *
-      factor
+        factor,
+      1
+    )
     expect(firstRowCells[3].text()).toContain(displayedSkillValue.toString())
 
     // Check total power (cell uses skillStrength = strength.skill.total * factor)

--- a/frontend/src/components/compare/compare-strength.vue
+++ b/frontend/src/components/compare/compare-strength.vue
@@ -274,18 +274,17 @@ export default defineComponent({
             : 0
 
         const skillStrength = this.showSkills ? Math.floor(memberProduction.strength.skill.total * timeWindowFactor) : 0
-        let skillValue = 0
 
         // TODO: this feels hacky, we're just summing all skill values, even with completely unrelated units. Doesn't make sense. But we're reworking how compare tool is working anyway, this has always worked suboptimally.
+        let skillValue = 0
         for (const activation of memberPokemon.skill.getUnits()) {
           skillValue += this.showSkills
-            ? MathUtils.round(
-                memberProduction.skillValue[activation].amountToSelf +
-                  memberProduction.skillValue[activation].amountToTeam,
-                1
-              ) * timeWindowFactor
+            ? defaultZero(memberProduction.skillValue[activation]?.amountToSelf) +
+              defaultZero(memberProduction.skillValue[activation]?.amountToTeam)
             : 0
         }
+        skillValue = MathUtils.round(skillValue * timeWindowFactor, 1)
+
         const total = Math.floor(berryPower + ingredientPower + skillStrength)
 
         production.push({


### PR DESCRIPTION
* Use `defaultZero` in case `memberProduction.skillValue[activation]` is undefined. This can happen when a mon got 0 skill triggers, such as when it's sneaky snacking.
* Round once at the end, rather than once for each unit, for slightly higher accuracy. (Though, it's still mixing unrelated units, which is questionable.)
* Multiply by `timeWindowFactor` _before_ rounding, so that we don't divide by 3 (for 8H) after rounding.