### PR TITLE
chore: remove row limit from compare tables

### DIFF
--- a/frontend/src/components/compare/compare-misc.vue
+++ b/frontend/src/components/compare/compare-misc.vue
@@ -3,7 +3,14 @@
   <v-row dense>
     <v-col cols="12">
       <v-card class="d-flex flex-column rounded-t-0 frosted-glass">
-        <v-data-table key="key" :items="members" :headers="headers" hide-default-footer class="bg-transparent">
+        <v-data-table
+          key="key"
+          :items="members"
+          :headers="headers"
+          hide-default-footer
+          class="bg-transparent"
+          items-per-page="-1"
+        >
           <template #item.member="{ item }">
             <div class="flex-center">
               <div style="overflow: hidden; width: 60px; height: 60px">

--- a/frontend/src/components/compare/compare-overview.vue
+++ b/frontend/src/components/compare/compare-overview.vue
@@ -3,7 +3,14 @@
   <v-row dense>
     <v-col cols="12">
       <v-card class="d-flex flex-column rounded-t-0 frosted-glass">
-        <v-data-table key="key" :items="members" :headers="headers" hide-default-footer class="bg-transparent">
+        <v-data-table
+          key="key"
+          :items="members"
+          :headers="headers"
+          hide-default-footer
+          class="bg-transparent"
+          items-per-page="-1"
+        >
           <template #item.member="{ item }">
             <div class="flex-center">
               <div style="overflow: hidden; width: 100px; height: 60px">

--- a/frontend/src/components/compare/compare-strength.vue
+++ b/frontend/src/components/compare/compare-strength.vue
@@ -111,6 +111,7 @@
           hide-default-footer
           class="bg-transparent"
           style="border-radius: 10px"
+          items-per-page="-1"
         >
           <template #item.member="{ item }">
             <div class="flex-center">


### PR DESCRIPTION
In Vue, `v-data-table` by default only allows up to 10 items to display at once. In the compare page, this happens to align with the most mons we allow the user to add. But if we ever decide to increase that, or if we clone those components for dynamic tier lists showing more than 10 mons, we'll need to remove the limit that Vue imposes. Setting `items-per-page="-1"` is how we remove the limit (which we've already done for the recipe table).