### PR TITLE
fix(ci): load common build when guides change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
   common:
     name: Common
     needs: changes
-    if: needs.changes.outputs.common == 'true' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
+    if: needs.changes.outputs.common == 'true' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.guides == 'true'
     uses: ./.github/workflows/build-test.yml
     with:
       working-directory: 'common'


### PR DESCRIPTION
Guides depends on Common. CI will skip building guides if there are no build artifacts for Common. Thus, Common needs to load its build artifacts into CI when Guides changes.

Yes, it feels circular. :sderp: