### PR TITLE
chore: include minor updates in dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,10 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 2
     groups:
-      patch-updates:
+      patch-and-minor-updates:
         update-types:
           - "patch"
+          - "minor"
 
   - package-ecosystem: "npm"
     directory: "/backend"
@@ -16,9 +17,10 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 2
     groups:
-      patch-updates:
+      patch-and-minor-updates:
         update-types:
           - "patch"
+          - "minor"
 
   - package-ecosystem: "npm"
     directory: "/frontend"
@@ -26,9 +28,10 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 2
     groups:
-      patch-updates:
+      patch-and-minor-updates:
         update-types:
           - "patch"
+          - "minor"
 
   - package-ecosystem: "npm"
     directory: "/docs"
@@ -36,9 +39,10 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 2
     groups:
-      patch-updates:
+      patch-and-minor-updates:
         update-types:
           - "patch"
+          - "minor"
 
   - package-ecosystem: "npm"
     directory: "/guides"
@@ -46,6 +50,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 2
     groups:
-      patch-updates:
+      patch-and-minor-updates:
         update-types:
           - "patch"
+          - "minor"


### PR DESCRIPTION
## Summary

Updated Dependabot configuration to group both patch and minor version updates together across all package ecosystems, rather than only grouping patch updates.

## Changes

- Renamed `patch-updates` group to `patch-and-minor-updates` in all five package ecosystem configurations (root, backend, frontend, docs, guides)
- Added `"minor"` to the `update-types` list alongside `"patch"` for each group

## Rationale

This change allows minor version updates (e.g., 1.0.0 → 1.1.0) to be grouped with patch updates in a single pull request, reducing the number of dependency update PRs while maintaining a conservative approach by excluding major version updates. This improves maintainability without introducing breaking changes.

https://claude.ai/code/session_0157Q4KCB793PtcLLARaDRD1