### PR TITLE
fix: set VAvatar default color to transparent

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -26,6 +26,11 @@ async function initializeApp() {
       themes: {
         darkTheme
       }
+    },
+    defaults: {
+      VAvatar: {
+        color: 'transparent'
+      }
     }
   })
 


### PR DESCRIPTION
Vuetify fixed a bug that was preventing the VAvatar background color from actually applying, in a version bump we recently upgraded to. We were evidently relying on that background color being transparent, so this restores the behavior we had expected.

This is what the bug looks like, screenshot from dev which contains current main branch deployed: 
<img width="987" height="309" alt="image" src="https://github.com/user-attachments/assets/d260d38f-90ab-43ac-8aab-15871f1b9683" />