### PR TITLE
fix: correct Cooking Power-Up S description text

### DIFF
--- a/common/src/types/mainskill/mainskills/cooking-power-up-s/cooking-power-up-s.test.ts
+++ b/common/src/types/mainskill/mainskills/cooking-power-up-s/cooking-power-up-s.test.ts
@@ -5,7 +5,7 @@ describe('CookingPowerUpS', () => {
   it('should have correct basic properties', () => {
     expect(CookingPowerUpS.name).toBe('Cooking Power-Up S');
     expect(CookingPowerUpS.description({ skillLevel: 1 })).toBe(
-      'Increases the quantity of Cooking items you get by 7.'
+      'Gives your pot room for 7 more ingredients next time you cook.'
     );
     expect(CookingPowerUpS.RP).toEqual([880, 1251, 1726, 2383, 3290, 4546, 5843]);
     expect(CookingPowerUpS.maxLevel).toBe(7);

--- a/common/src/types/mainskill/mainskills/cooking-power-up-s/cooking-power-up-s.ts
+++ b/common/src/types/mainskill/mainskills/cooking-power-up-s/cooking-power-up-s.ts
@@ -7,7 +7,7 @@ export const CookingPowerUpS = new (class extends Mainskill {
   potSizeAmounts = [7, 10, 12, 17, 22, 27, 31];
   image = 'pot';
   description = (params: AmountParams) =>
-    `Increases the quantity of Cooking items you get by ${this.potSizeAmounts[params.skillLevel - 1]}.`;
+    `Gives your pot room for ${this.potSizeAmounts[params.skillLevel - 1]} more ingredients next time you cook.`;
   activations: ActivationsType = {
     potSize: {
       unit: 'pot size',


### PR DESCRIPTION
## Summary
- Cooking Power-Up S's description said "Increases the quantity of Cooking items you get by X" which doesn't match the in-game text
- Corrected it to "Gives your pot room for X more ingredients next time you cook." (same phrasing pattern already used by the Minus variant)