### PR TITLE
fix: include all-specialists in every specialty filter chip

### DIFF
--- a/common/src/utils/pokemon-utils/pokemon-constructors.ts
+++ b/common/src/utils/pokemon-utils/pokemon-constructors.ts
@@ -4,7 +4,7 @@ import type { GenderRatio } from '../../types/gender';
 import type { Ingredient, IngredientSet } from '../../types/ingredient';
 import type { Mainskill } from '../../types/mainskill';
 import type { Pokemon, PokemonSpecialty } from '../../types/pokemon';
-import { calculatePityProcThreshold } from '../stat-utils/stat-utils';
+import { calculatePityProcThreshold, hasSpecialty } from '../stat-utils/stat-utils';
 import { evolvesFrom, evolvesInto } from './evolution-utils';
 
 export type IngredientDefinition = {
@@ -186,7 +186,7 @@ export function getIngredientSet(
 ): IngredientSet {
   const baseStrength = ingredientA.value;
   const levelFactor = level === 0 ? 1 : level === 30 ? 2.25 : 3.6;
-  const specialtyFactor = specialty === 'ingredient' || specialty === 'all' ? 2 : 1;
+  const specialtyFactor = hasSpecialty(specialty, 'ingredient') ? 2 : 1;
   return {
     amount: Math.round((baseStrength * levelFactor * specialtyFactor) / ingredientDrop.value),
     ingredient: ingredientDrop

--- a/common/src/utils/stat-utils/stat-utils.ts
+++ b/common/src/utils/stat-utils/stat-utils.ts
@@ -17,6 +17,10 @@ import {
 } from '../../types/subskill/subskills';
 import { MathUtils } from '../../utils/math-utils';
 
+export function hasSpecialty(specialty: PokemonSpecialty, expected: PokemonSpecialty): boolean {
+  return specialty === expected || specialty === 'all';
+}
+
 export function calculateIngredientPercentage(params: { pokemon: Pokemon; nature: Nature; subskills: Set<string> }) {
   const { pokemon, nature, subskills } = params;
   const ingredientSubskills = extractIngredientSubskills(subskills);
@@ -48,7 +52,7 @@ export function calculateSkillPercentageWithPityProc(pokemon: Pokemon, subskills
 }
 
 export function calculatePityProcThreshold(specialty: PokemonSpecialty, frequency: number) {
-  return specialty === 'skill' || specialty === 'all' ? Math.floor(144000 / frequency) : 78;
+  return hasSpecialty(specialty, 'skill') ? Math.floor(144000 / frequency) : 78;
 }
 
 export function extractTriggerSubskills(subskills: Set<string>) {
@@ -63,7 +67,7 @@ export function countErbUsers(erb: number, subskills: Set<string>) {
 }
 
 export function calculateNrOfBerriesPerDrop(specialty: PokemonSpecialty, subskills: Set<string>) {
-  let result = specialty === 'berry' || specialty === 'all' ? 2 : 1;
+  let result = hasSpecialty(specialty, 'berry') ? 2 : 1;
   if (subskills.has(BERRY_FINDING_S.name)) {
     result += 1;
   }

--- a/frontend/src/components/pokemon-input/PokemonSearch.test.ts
+++ b/frontend/src/components/pokemon-input/PokemonSearch.test.ts
@@ -4,7 +4,7 @@ import { useDialogStore } from '@/stores/dialog-store/dialog-store'
 import { usePokemonSearchStore } from '@/stores/pokemon-search-store'
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { BULBASAUR, COMPLETE_POKEDEX, ingredient } from 'sleepapi-common'
+import { BULBASAUR, COMPLETE_POKEDEX, DARKRAI, ingredient } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -333,6 +333,30 @@ describe('PokemonSearch', () => {
         expect(store.finalStageOnly).toBe(false)
       }
     })
+  })
+
+  describe('Specialty Filtering', () => {
+    const findAvatarSrcs = (w: VueWrapper<InstanceType<typeof PokemonSearch>>) =>
+      w
+        .findAll('.v-avatar img')
+        .map((img) => img.attributes('src') || '')
+        .map((src) => src.toLowerCase())
+
+    it.each(['berry', 'ingredient', 'skill'])(
+      'includes all-specialists like Darkrai when filtering by %s',
+      async (specialty) => {
+        const localWrapper = mount(PokemonSearch)
+
+        const chip = localWrapper.findAll('.v-chip').find((c) => c.text().toLowerCase() === specialty)
+        expect(chip).toBeDefined()
+
+        await chip!.trigger('click')
+        await nextTick()
+
+        const srcs = findAvatarSrcs(localWrapper)
+        expect(srcs.some((src) => src.includes(DARKRAI.name.toLowerCase()))).toBe(true)
+      }
+    )
   })
 
   describe('Exact Ingredient Matching', () => {

--- a/frontend/src/components/pokemon-input/PokemonSearch.vue
+++ b/frontend/src/components/pokemon-input/PokemonSearch.vue
@@ -154,6 +154,7 @@ import { useUserStore } from '@/stores/user-store'
 import {
   capitalize,
   COMPLETE_POKEDEX,
+  hasSpecialty,
   type Pokemon,
   type PokemonInstanceExt,
   type PokemonSpecialty
@@ -286,7 +287,8 @@ const filteredPokemon: ComputedRef<PokemonWithPath[]> = computed(() => {
   }
 
   const specialtyFilter = (p: PokemonWithPath) =>
-    selectedSpecialties.value.length === 0 || selectedSpecialties.value.some((s) => p.pokemon.specialty === s)
+    selectedSpecialties.value.length === 0 ||
+    selectedSpecialties.value.some((s) => hasSpecialty(p.pokemon.specialty, s))
   const finalStageFilter = (p: PokemonWithPath) =>
     !finalStageOnly.value || pokemonSearchStore.showPokebox || p.pokemon.remainingEvolutions === 0
 


### PR DESCRIPTION
## Summary
- Darkrai's specialty is `'all'`, but the Pokemon search specialty filter did an exact match (`specialty === s`), so it never matched the Berry, Ingredient, or Skill chips - Darkrai showed under none of them.
- Filter now also passes when a Pokemon's specialty is `'all'`, consistent with how `common` already treats the all-specialist elsewhere (e.g. `stat-utils.ts`).

## Test plan
- [x] Added a test that fails without the fix and passes with it, for each of the Berry/Ingredient/Skill chips
- [x] `npx vitest --run` on PokemonSearch.test.ts (21 passed)
- [x] `npm run type-check` (frontend)