### PR TITLE
fix: always use `hasSpecialty` rather than `===`

### DIFF
--- a/backend/src/public/swagger.json
+++ b/backend/src/public/swagger.json
@@ -624,6 +624,10 @@
 							"application/json": {
 								"schema": {
 									"properties": {
+										"pityProcThreshold": {
+											"type": "number",
+											"format": "double"
+										},
 										"ingredient60": {
 											"items": {
 												"$ref": "#/components/schemas/IngredientSet"
@@ -727,6 +731,7 @@
 										}
 									},
 									"required": [
+										"pityProcThreshold",
 										"ingredient60",
 										"ingredient30",
 										"ingredient0",

--- a/backend/src/services/calculator/skill/skill-calculator.test.ts
+++ b/backend/src/services/calculator/skill/skill-calculator.test.ts
@@ -5,7 +5,7 @@ import {
   calculateSkillProcs,
   scheduleSkillEvents
 } from '@src/services/calculator/skill/skill-calculator.js';
-import { ChargeStrengthM, MathUtils, PINSIR, berry, ingredient } from 'sleepapi-common';
+import { ChargeStrengthM, MathUtils, PINSIR, berry, commonMocks, ingredient } from 'sleepapi-common';
 import { describe, expect, it } from 'vitest';
 
 describe('calculateSkillProcs', () => {
@@ -21,12 +21,16 @@ describe('calculate procs from start', () => {
 });
 
 describe('calculateAverageNumberOfSkillProcsForHelps', () => {
-  describe('non-skill specialists', () => {
+  const berrySpecialist = commonMocks.mockPokemon({ specialty: 'berry' });
+  const ingredientSpecialist = commonMocks.mockPokemon({ specialty: 'ingredient' });
+  const skillSpecialist = commonMocks.mockPokemon({ specialty: 'skill' });
+  const allSpecialist = commonMocks.mockPokemon({ specialty: 'all' });
+  describe('berry/ingredient specialists', () => {
     it('shall return 0 for 0 helps regardless of skill percentage', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 0.5,
         helps: 0,
-        pokemonSpecialty: 'berry'
+        pokemon: berrySpecialist
       });
       expect(odds).toBe(0);
     });
@@ -35,7 +39,7 @@ describe('calculateAverageNumberOfSkillProcsForHelps', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 1,
         helps: 5,
-        pokemonSpecialty: 'berry'
+        pokemon: ingredientSpecialist
       });
       expect(odds).toBe(1);
     });
@@ -44,7 +48,7 @@ describe('calculateAverageNumberOfSkillProcsForHelps', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 0.25,
         helps: 4,
-        pokemonSpecialty: 'berry'
+        pokemon: berrySpecialist
       });
       const expectedOdds = 1 - Math.pow(0.75, 4);
       expect(odds).toBeCloseTo(expectedOdds);
@@ -54,7 +58,7 @@ describe('calculateAverageNumberOfSkillProcsForHelps', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 0,
         helps: 5,
-        pokemonSpecialty: 'berry'
+        pokemon: ingredientSpecialist
       });
       expect(odds).toBe(0);
     });
@@ -63,7 +67,7 @@ describe('calculateAverageNumberOfSkillProcsForHelps', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 0.5,
         helps: 3,
-        pokemonSpecialty: 'berry'
+        pokemon: berrySpecialist
       });
       expect(odds).toBeGreaterThan(0);
       expect(odds).toBeLessThan(1);
@@ -73,19 +77,19 @@ describe('calculateAverageNumberOfSkillProcsForHelps', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 0.1,
         helps: 50,
-        pokemonSpecialty: 'berry'
+        pokemon: ingredientSpecialist
       });
       expect(odds).toBeGreaterThan(0);
       expect(odds).toBeLessThan(1);
     });
   });
 
-  describe('skill specialists', () => {
+  describe('skill/all specialists', () => {
     it('shall return 0 for 0 helps regardless of skill percentage', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 0.5,
         helps: 0,
-        pokemonSpecialty: 'skill'
+        pokemon: skillSpecialist
       });
       expect(odds).toBe(0);
     });
@@ -94,7 +98,7 @@ describe('calculateAverageNumberOfSkillProcsForHelps', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 1,
         helps: 5,
-        pokemonSpecialty: 'skill'
+        pokemon: allSpecialist
       });
       expect(odds).toBe(2);
     });
@@ -103,7 +107,7 @@ describe('calculateAverageNumberOfSkillProcsForHelps', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 0.25,
         helps: 4,
-        pokemonSpecialty: 'skill'
+        pokemon: skillSpecialist
       });
       const oddsZero = Math.pow(0.75, 4);
       const oddsOne = Math.pow(0.75, 3) * 0.25 * 4;
@@ -116,7 +120,7 @@ describe('calculateAverageNumberOfSkillProcsForHelps', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 0.25,
         helps: 10,
-        pokemonSpecialty: 'skill'
+        pokemon: allSpecialist
       });
       const oddsZero = Math.pow(0.75, 10);
       const oddsOne = Math.pow(0.75, 9) * 0.25 * 10;
@@ -129,7 +133,7 @@ describe('calculateAverageNumberOfSkillProcsForHelps', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 0,
         helps: 5,
-        pokemonSpecialty: 'skill'
+        pokemon: skillSpecialist
       });
       expect(odds).toBe(0);
     });
@@ -138,7 +142,7 @@ describe('calculateAverageNumberOfSkillProcsForHelps', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 0.5,
         helps: 3,
-        pokemonSpecialty: 'skill'
+        pokemon: allSpecialist
       });
       expect(odds).toBeGreaterThan(0);
       expect(odds).toBeLessThan(2);
@@ -148,7 +152,7 @@ describe('calculateAverageNumberOfSkillProcsForHelps', () => {
       const odds = calculateAverageNumberOfSkillProcsForHelps({
         skillPercentage: 0.1,
         helps: 50,
-        pokemonSpecialty: 'skill'
+        pokemon: skillSpecialist
       });
       expect(odds).toBeGreaterThan(0);
       expect(odds).toBeLessThan(2);

--- a/backend/src/services/calculator/skill/skill-calculator.ts
+++ b/backend/src/services/calculator/skill/skill-calculator.ts
@@ -1,5 +1,6 @@
 import type { PokemonProduce } from '@src/domain/combination/produce.js';
-import type { PokemonSpecialty, SkillActivation } from 'sleepapi-common';
+import type { Pokemon } from 'sleepapi-common';
+import { hasSpecialty, type SkillActivation } from 'sleepapi-common';
 import { createSkillEvent } from './activation/skill-activation.js';
 
 export function calculateSkillProcs(nrOfHelps: number, skillPercentage: number) {
@@ -9,15 +10,15 @@ export function calculateSkillProcs(nrOfHelps: number, skillPercentage: number) 
 export function calculateAverageNumberOfSkillProcsForHelps(params: {
   skillPercentage: number;
   helps: number;
-  pokemonSpecialty: PokemonSpecialty;
+  pokemon: Pokemon;
 }): number {
-  const { skillPercentage, helps, pokemonSpecialty } = params;
+  const { skillPercentage, helps, pokemon } = params;
 
   // Calculate chance of zero procs
   const chanceOfZeroProcs = Math.pow(1 - skillPercentage, helps);
 
   // Skill specialists can bank 2 procs
-  if (pokemonSpecialty !== 'skill') {
+  if (!hasSpecialty(pokemon, 'skill')) {
     return 1 - chanceOfZeroProcs;
   } else {
     const chanceOfOneProc = Math.pow(1 - skillPercentage, helps - 1) * skillPercentage * helps;

--- a/backend/src/services/simulation-service/monte-carlo/randomized-simulator.ts
+++ b/backend/src/services/simulation-service/monte-carlo/randomized-simulator.ts
@@ -30,6 +30,7 @@ import {
   ChargeEnergySMoonlight,
   emptyProduce,
   EnergizingCheerS,
+  hasSpecialty,
   MathUtils,
   RandomUtils
 } from 'sleepapi-common';
@@ -123,7 +124,7 @@ export function randomizedSimulation(params: {
         }
       }
       skillProcsNight += 1;
-      if (skillProcsNight === 2 || (pokemon.specialty !== 'skill' && pokemon.specialty !== 'all')) {
+      if (skillProcsNight === 2 || !hasSpecialty(pokemon, 'skill')) {
         break;
       }
     }

--- a/backend/src/services/simulation-service/simulation-service.ts
+++ b/backend/src/services/simulation-service/simulation-service.ts
@@ -120,7 +120,7 @@ export function setupAndRunProductionSimulation(params: {
 
   const mealTimes = getDefaultMealTimes(daySleepInfo.period).sorted;
 
-  const berriesPerDrop = calculateNrOfBerriesPerDrop(pokemonSet.pokemon.specialty, subskills);
+  const berriesPerDrop = calculateNrOfBerriesPerDrop(pokemonSet.pokemon, subskills);
   const sneakySnackBerries: BerrySet[] = [
     {
       amount: berriesPerDrop,
@@ -305,7 +305,7 @@ export function generateSkillActivations(params: {
     oddsOfNightSkillProc = calculateAverageNumberOfSkillProcsForHelps({
       skillPercentage,
       helps: nightHelpsBeforeSS,
-      pokemonSpecialty: pokemonWithAverageProduce.pokemon.specialty
+      pokemon: pokemonWithAverageProduce.pokemon
     });
     nrOfDayHelps = dayHelps;
   }

--- a/backend/src/services/simulation-service/team-simulator/member-state/member-state.ts
+++ b/backend/src/services/simulation-service/team-simulator/member-state/member-state.ts
@@ -42,6 +42,7 @@ import {
   emptyIngredientInventoryFloat,
   emptyIngredientInventoryInt,
   flatToIngredientSet,
+  hasSpecialty,
   ingredientSetToFloatFlat,
   ingredientSetToIntFlat,
   multiplyProduce,
@@ -234,7 +235,7 @@ export class MemberState {
       }
     ]);
     const berriesPerDrop = calculateNrOfBerriesPerDrop(
-      member.pokemonWithIngredients.pokemon.specialty,
+      member.pokemonWithIngredients.pokemon,
       member.settings.subskills
     );
 
@@ -847,7 +848,7 @@ export class MemberState {
 
     // Expert mode ingredient modifier grants +1 ingredient per help for favored berries;
     // ingredient specialists additionally roll for a further +1 at runtime.
-    this.expertIngredientSpecialistBonus = pokemon.specialty === 'ingredient';
+    this.expertIngredientSpecialistBonus = hasSpecialty(pokemon, 'ingredient');
     this.level0IngredientAmount += 1;
     if (this.level30IngredientAmount !== undefined) {
       this.level30IngredientAmount += 1;

--- a/backend/src/services/simulation-service/team-simulator/team-simulator-utils.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator-utils.ts
@@ -75,7 +75,7 @@ class TeamSimulatorUtilsImpl {
       { amount: 1, berry: member.pokemonWithIngredients.pokemon.berry, level: member.settings.level }
     ]);
     const berriesPerDrop = calculateNrOfBerriesPerDrop(
-      member.pokemonWithIngredients.pokemon.specialty,
+      member.pokemonWithIngredients.pokemon,
       member.settings.subskills
     );
 

--- a/backend/src/services/simulation-service/team-simulator/team-simulator.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator.test.ts
@@ -6,7 +6,7 @@ import type {
 } from '@src/services/simulation-service/team-simulator/skill-state/skill-state-types.js';
 import { TeamSimulator } from '@src/services/simulation-service/team-simulator/team-simulator.js';
 import { mocks } from '@src/vitest/index.js';
-import type { Berry, PokemonWithIngredients, TeamMemberExt, TeamSettingsExt } from 'sleepapi-common';
+import type { Berry, PokemonSpecialty, PokemonWithIngredients, TeamMemberExt, TeamSettingsExt } from 'sleepapi-common';
 import {
   BASE_FAVORED_BERRY_MULTIPLIER,
   BerryBurstDisguise,
@@ -451,7 +451,7 @@ describe('TeamSimulator', () => {
 
     const buildFavoredMember = (params: {
       carrySize: number;
-      specialty: 'berry' | 'ingredient';
+      specialty: PokemonSpecialty;
       externalId: string;
     }): TeamMemberExt => {
       const pokemon = commonMocks.mockPokemon({

--- a/backend/src/services/solve/utils/solve-utils.ts
+++ b/backend/src/services/solve/utils/solve-utils.ts
@@ -35,6 +35,7 @@ import {
   CookingAssistSBulkUp,
   CookingPowerUpS,
   getAllIngredientLists,
+  hasSpecialty,
   HelperBoost,
   ingredient,
   INGREDIENT_SUPPORT_MAINSKILLS,
@@ -199,7 +200,7 @@ export function pokedexToMembers(params: { pokedex: Pokedex; level: number; camp
     ];
     const pokemonWithIngredients: PokemonWithIngredients = { pokemon: pkmn, ingredientList: AAA };
 
-    const isSupportSkillMon = pkmn.specialty === 'skill' && INGREDIENT_SUPPORT_MAINSKILLS_SET.has(pkmn.skill.name);
+    const isSupportSkillMon = hasSpecialty(pkmn, 'skill') && INGREDIENT_SUPPORT_MAINSKILLS_SET.has(pkmn.skill.name);
     const optimalSettings: Optimal = isSupportSkillMon
       ? Optimal.skill(pkmn, 4, pkmn.skill.maxLevel)
       : Optimal.ingredient(pkmn, 4, pkmn.skill.maxLevel);

--- a/common/src/types/modifier/modifier.ts
+++ b/common/src/types/modifier/modifier.ts
@@ -113,16 +113,16 @@ export type ExternalCondition<TValue = unknown> = {
  * Uses distributive conditional types to handle union types correctly
  *
  * @example
- * // Modifier that reduces frequency by 10% only for berry specialists
+ * // Modifier that reduces frequency by 10% only for not-fully-evolved Pokemon
  * const modifier: Modifier<Pokemon> = {
  *   type: 'Pokemon',
  *   path: 'frequency',
  *   operation: '*',
  *   value: 0.9,
  *   condition: {
- *     path: 'specialty',
- *     operation: '=',
- *     value: 'berry'
+ *     path: 'remainingEvolutions',
+ *     operation: '>',
+ *     value: '0'
  *   }
  * };
  */

--- a/common/src/types/type/path-value.test.ts
+++ b/common/src/types/type/path-value.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from 'vitest';
+import type { PokemonSpecialty } from '../pokemon';
 import type { PathValue } from './path-value';
 
 describe('PathValue type utility', () => {
@@ -118,7 +119,7 @@ describe('PathValue type utility', () => {
     interface SimplePokemon {
       name: string;
       frequency: number;
-      specialty: 'berry' | 'ingredient' | 'skill';
+      specialty: PokemonSpecialty;
       berry: {
         name: string;
         power: number;

--- a/common/src/types/type/type-paths.test.ts
+++ b/common/src/types/type/type-paths.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { PokemonSpecialty } from '../pokemon';
 import type { PathKeys } from './type-paths';
 
 describe('PathKeys', () => {
@@ -326,7 +327,7 @@ describe('PathKeys', () => {
       interface TestPokemon {
         name: string;
         frequency: number;
-        specialty: 'berry' | 'ingredient' | 'skill';
+        specialty: PokemonSpecialty;
         berry: {
           name: string;
           power: number;

--- a/common/src/utils/pokemon-utils/pokemon-constructors.ts
+++ b/common/src/utils/pokemon-utils/pokemon-constructors.ts
@@ -4,7 +4,7 @@ import type { GenderRatio } from '../../types/gender';
 import type { Ingredient, IngredientSet } from '../../types/ingredient';
 import type { Mainskill } from '../../types/mainskill';
 import type { Pokemon, PokemonSpecialty } from '../../types/pokemon';
-import { calculatePityProcThreshold, hasSpecialty } from '../stat-utils/stat-utils';
+import { calculatePityProcThreshold, matchesSpecialty } from '../stat-utils/stat-utils';
 import { evolvesFrom, evolvesInto } from './evolution-utils';
 
 export type IngredientDefinition = {
@@ -186,7 +186,7 @@ export function getIngredientSet(
 ): IngredientSet {
   const baseStrength = ingredientA.value;
   const levelFactor = level === 0 ? 1 : level === 30 ? 2.25 : 3.6;
-  const specialtyFactor = hasSpecialty(specialty, 'ingredient') ? 2 : 1;
+  const specialtyFactor = matchesSpecialty(specialty, 'ingredient') ? 2 : 1;
   return {
     amount: Math.round((baseStrength * levelFactor * specialtyFactor) / ingredientDrop.value),
     ingredient: ingredientDrop

--- a/common/src/utils/rp-utils/rp.ts
+++ b/common/src/utils/rp-utils/rp.ts
@@ -119,7 +119,7 @@ export class RP {
   }
 
   get berryFactor() {
-    const berriesPerDrop = calculateNrOfBerriesPerDrop(this.pokemon.specialty, this.subskills);
+    const berriesPerDrop = calculateNrOfBerriesPerDrop(this.pokemon, this.subskills);
     const berryValue =
       berriesPerDrop *
       Math.max(

--- a/common/src/utils/stat-utils/stat-utils.test.ts
+++ b/common/src/utils/stat-utils/stat-utils.test.ts
@@ -146,24 +146,28 @@ describe('extractTriggerSubskills', () => {
 });
 
 describe('calculateNrOfBerriesPerDrop', () => {
+  const berrySpecialist = mockPokemon({ specialty: 'berry' });
+  const ingredientSpecialist = mockPokemon({ specialty: 'ingredient' });
+  const skillSpecialist = mockPokemon({ specialty: 'skill' });
+  const allSpecialist = mockPokemon({ specialty: 'all' });
   it('shall give 2 berries for berry specialty', () => {
-    expect(calculateNrOfBerriesPerDrop('berry', new Set())).toBe(2);
+    expect(calculateNrOfBerriesPerDrop(berrySpecialist, new Set())).toBe(2);
   });
 
   it('shall give 3 berries for berry specialty with BFS', () => {
-    expect(calculateNrOfBerriesPerDrop('berry', new Set([BERRY_FINDING_S.name]))).toBe(3);
+    expect(calculateNrOfBerriesPerDrop(berrySpecialist, new Set([BERRY_FINDING_S.name]))).toBe(3);
   });
 
   it('shall give 3 berries for all specialty with BFS', () => {
-    expect(calculateNrOfBerriesPerDrop('all', new Set([BERRY_FINDING_S.name]))).toBe(3);
+    expect(calculateNrOfBerriesPerDrop(allSpecialist, new Set([BERRY_FINDING_S.name]))).toBe(3);
   });
 
   it('shall give 1 berry for ingredient specialty', () => {
-    expect(calculateNrOfBerriesPerDrop('ingredient', new Set())).toBe(1);
+    expect(calculateNrOfBerriesPerDrop(ingredientSpecialist, new Set())).toBe(1);
   });
 
   it('shall give 2 berries for skill specialty with BFS', () => {
-    expect(calculateNrOfBerriesPerDrop('skill', new Set([BERRY_FINDING_S.name]))).toBe(2);
+    expect(calculateNrOfBerriesPerDrop(skillSpecialist, new Set([BERRY_FINDING_S.name]))).toBe(2);
   });
 });
 

--- a/common/src/utils/stat-utils/stat-utils.ts
+++ b/common/src/utils/stat-utils/stat-utils.ts
@@ -17,7 +17,14 @@ import {
 } from '../../types/subskill/subskills';
 import { MathUtils } from '../../utils/math-utils';
 
-export function hasSpecialty(specialty: PokemonSpecialty, expected: PokemonSpecialty): boolean {
+export function hasSpecialty(mon: Pokemon, expected: PokemonSpecialty): boolean {
+  return mon.specialty === expected || mon.specialty === 'all';
+}
+
+/**
+ * @see `hasSpecialty` if you have access to a `Pokemon` object.
+ */
+export function matchesSpecialty(specialty: PokemonSpecialty, expected: PokemonSpecialty): boolean {
   return specialty === expected || specialty === 'all';
 }
 
@@ -52,7 +59,7 @@ export function calculateSkillPercentageWithPityProc(pokemon: Pokemon, subskills
 }
 
 export function calculatePityProcThreshold(specialty: PokemonSpecialty, frequency: number) {
-  return hasSpecialty(specialty, 'skill') ? Math.floor(144000 / frequency) : 78;
+  return matchesSpecialty(specialty, 'skill') ? Math.floor(144000 / frequency) : 78;
 }
 
 export function extractTriggerSubskills(subskills: Set<string>) {
@@ -66,8 +73,8 @@ export function countErbUsers(erb: number, subskills: Set<string>) {
   return Math.max(Math.min(erb + subskillErb, MAX_TEAM_SIZE), 0);
 }
 
-export function calculateNrOfBerriesPerDrop(specialty: PokemonSpecialty, subskills: Set<string>) {
-  let result = hasSpecialty(specialty, 'berry') ? 2 : 1;
+export function calculateNrOfBerriesPerDrop(mon: Pokemon, subskills: Set<string>) {
+  let result = hasSpecialty(mon, 'berry') ? 2 : 1;
   if (subskills.has(BERRY_FINDING_S.name)) {
     result += 1;
   }

--- a/frontend/src/components/calculator/results/member-results/island-impact/island-impact.vue
+++ b/frontend/src/components/calculator/results/member-results/island-impact/island-impact.vue
@@ -50,6 +50,7 @@ import {
   BASE_FAVORED_BERRY_MULTIPLIER,
   capitalize,
   EXPERT_MODE_BERRY_BONUS_MULTIPLIER,
+  hasSpecialty,
   type IslandInstance,
   type PokemonInstanceExt
 } from 'sleepapi-common'
@@ -178,7 +179,7 @@ const effects = computed<IslandEffect[]>(() => {
 
     if (isFavored.value) {
       if (expertMode.value.randomBonus === 'ingredient') {
-        const ingredientSpecialist = props.member.pokemon.specialty === 'ingredient'
+        const ingredientSpecialist = hasSpecialty(props.member.pokemon, 'ingredient')
         result.push(ingredientSpecialist ? expertIngredientSpecialtyBonus : expertIngredientBonus)
       } else if (expertMode.value.randomBonus === 'berry') {
         result.push(expertBerryBonus)

--- a/frontend/src/components/pokemon-input/PokemonSearch.vue
+++ b/frontend/src/components/pokemon-input/PokemonSearch.vue
@@ -287,8 +287,7 @@ const filteredPokemon: ComputedRef<PokemonWithPath[]> = computed(() => {
   }
 
   const specialtyFilter = (p: PokemonWithPath) =>
-    selectedSpecialties.value.length === 0 ||
-    selectedSpecialties.value.some((s) => hasSpecialty(p.pokemon.specialty, s))
+    selectedSpecialties.value.length === 0 || selectedSpecialties.value.some((s) => hasSpecialty(p.pokemon, s))
   const finalStageFilter = (p: PokemonWithPath) =>
     !finalStageOnly.value || pokemonSearchStore.showPokebox || p.pokemon.remainingEvolutions === 0
 


### PR DESCRIPTION
A bunch of places in the code use equality comparisons on Pokemon specialties. We nearly never want this, because All specialists should be impacted by everything that impacts other specialties. Now that tindo has added a helper function to replace `foo === specialty || foo === 'all'`, we should use it nearly everywhere we compare specialties.

This revealed some bugs in how expert mode handled All specialists, which have been fixed.