### PR TITLE
fix: hide shiny toggle for shiny-locked pokemon

### DIFF
--- a/common/src/types/pokemon/__snapshots__/pokemon.test.ts.snap
+++ b/common/src/types/pokemon/__snapshots__/pokemon.test.ts.snap
@@ -8454,6 +8454,7 @@ exports[`COMPLETE_POKEDEX > shall not change DARKRAI unexpectedly 1`] = `
   "pokedexNumber": 491,
   "previousEvolutions": 0,
   "remainingEvolutions": 0,
+  "shinyLocked": true,
   "skill": {
     "RP": [
       2400,
@@ -19330,6 +19331,7 @@ exports[`COMPLETE_POKEDEX > shall not change MEW unexpectedly 1`] = `
   "pokedexNumber": 151,
   "previousEvolutions": 0,
   "remainingEvolutions": 0,
+  "shinyLocked": true,
   "skill": {
     "RP": [
       1,

--- a/common/src/types/pokemon/all-pokemon.ts
+++ b/common/src/types/pokemon/all-pokemon.ts
@@ -63,7 +63,8 @@ export const MEW: Pokemon = createAllSpecialist({
       { amount: 4, ingredient: GLOSSY_AVOCADO }
     ]
   },
-  skill: Versatile
+  skill: Versatile,
+  shinyLocked: true
 });
 
 export const DARKRAI: Pokemon = createAllSpecialist({
@@ -111,7 +112,8 @@ export const DARKRAI: Pokemon = createAllSpecialist({
       { amount: 4, ingredient: ROUSING_COFFEE }
     ]
   },
-  skill: ChargeStrengthMBadDreams
+  skill: ChargeStrengthMBadDreams,
+  shinyLocked: true
 });
 
 export const OPTIMAL_ALL_SPECIALISTS: Pokemon[] = [MEW, DARKRAI];

--- a/common/src/types/pokemon/pokemon.ts
+++ b/common/src/types/pokemon/pokemon.ts
@@ -36,6 +36,7 @@ export interface Pokemon {
   ingredient60: IngredientSet[];
   skill: Mainskill;
   pityProcThreshold: number;
+  shinyLocked?: boolean;
 }
 
 export type Pokedex = Pokemon[];

--- a/common/src/utils/pokemon-utils/pokemon-constructors.ts
+++ b/common/src/utils/pokemon-utils/pokemon-constructors.ts
@@ -35,6 +35,7 @@ function createPokemon(params: {
   remainingEvolutions: number;
   ingredients: IngredientSpecification;
   skill: Mainskill;
+  shinyLocked?: boolean;
 }): Pokemon {
   const { ingredients, ...otherParams } = params;
   const { name, specialty, frequency } = otherParams;
@@ -65,6 +66,7 @@ export function createAllSpecialist(params: {
   remainingEvolutions: number;
   ingredients: IngredientSpecification;
   skill: Mainskill;
+  shinyLocked?: boolean;
 }): Pokemon {
   return createPokemon({
     ...params,
@@ -85,6 +87,7 @@ export function createBerrySpecialist(params: {
   remainingEvolutions: number;
   ingredients: IngredientSpecification;
   skill: Mainskill;
+  shinyLocked?: boolean;
 }): Pokemon {
   return createPokemon({
     ...params,
@@ -105,6 +108,7 @@ export function createIngredientSpecialist(params: {
   remainingEvolutions: number;
   ingredients: IngredientSpecification;
   skill: Mainskill;
+  shinyLocked?: boolean;
 }): Pokemon {
   return createPokemon({
     ...params,
@@ -125,6 +129,7 @@ export function createSkillSpecialist(params: {
   remainingEvolutions: number;
   ingredients: IngredientSpecification;
   skill: Mainskill;
+  shinyLocked?: boolean;
 }): Pokemon {
   return createPokemon({
     ...params,

--- a/frontend/src/components/pokemon-input/pokemon-input.test.ts
+++ b/frontend/src/components/pokemon-input/pokemon-input.test.ts
@@ -7,6 +7,7 @@ import { mount } from '@vue/test-utils'
 import {
   CarrySizeUtils,
   commonMocks,
+  DARKRAI,
   nature,
   RandomUtils,
   SNEASEL,
@@ -97,6 +98,31 @@ describe('PokemonInput', () => {
     expect(pokemonInstance.skillLevel).toBe(2)
     expect(pokemonInstance.gender).toEqual('female')
     expect(pokemonInstance.carrySize).toBe(CarrySizeUtils.baseCarrySize(WEAVILE))
+  })
+
+  it('toggles shiny state correctly', async () => {
+    const shinyButton = wrapper.find('#shinyButton')
+    expect(wrapper.vm.pokemonInstance.shiny).toBe(false)
+
+    await shinyButton.trigger('click')
+    expect(wrapper.vm.pokemonInstance.shiny).toBe(true)
+
+    await shinyButton.trigger('click')
+    expect(wrapper.vm.pokemonInstance.shiny).toBe(false)
+  })
+
+  it('hides the shiny toggle for shiny-locked pokemon', () => {
+    wrapper.vm.updatePokemon(mocks.createMockPokemon({ pokemon: DARKRAI }))
+    expect(wrapper.vm.pokemonInstance.pokemon.shinyLocked).toBe(true)
+    return wrapper.vm.$nextTick().then(() => {
+      expect(wrapper.find('#shinyButton').exists()).toBe(false)
+    })
+  })
+
+  it('does not toggle shiny for shiny-locked pokemon', () => {
+    wrapper.vm.updatePokemon(mocks.createMockPokemon({ pokemon: DARKRAI, shiny: false }))
+    wrapper.vm.toggleShiny()
+    expect(wrapper.vm.pokemonInstance.shiny).toBe(false)
   })
 
   it('updates name correctly', async () => {

--- a/frontend/src/components/pokemon-input/pokemon-input.vue
+++ b/frontend/src/components/pokemon-input/pokemon-input.vue
@@ -23,7 +23,16 @@
     </div>
 
     <v-sheet color="surface" width="100%" :height="85" location="top left" position="absolute" style="margin-top: 50px">
-      <v-btn icon color="surface" elevation="0" style="right: 4px; position: absolute" size="40" @click="toggleShiny">
+      <v-btn
+        id="shinyButton"
+        v-if="!pokemonInstance.pokemon.shinyLocked"
+        icon
+        color="surface"
+        elevation="0"
+        style="right: 4px; position: absolute"
+        size="40"
+        @click="toggleShiny"
+      >
         <v-icon v-if="pokemonInstance.shiny" color="strength" size="24">mdi-creation</v-icon>
         <v-icon v-else size="24">mdi-creation-outline</v-icon>
       </v-btn>
@@ -238,6 +247,9 @@ export default defineComponent({
       }
     },
     toggleShiny() {
+      if (this.pokemonInstance.pokemon.shinyLocked) {
+        return
+      }
       this.pokemonInstance.shiny = !this.pokemonInstance.shiny
     },
     updateGender(gender: PokemonGender) {

--- a/frontend/src/services/utils/pokemon-instance-utils.test.ts
+++ b/frontend/src/services/utils/pokemon-instance-utils.test.ts
@@ -2,6 +2,7 @@ import { PokemonInstanceUtils } from '@/services/utils/pokemon-instance-utils'
 import { mocks } from '@/vitest'
 import {
   CarrySizeUtils,
+  DARKRAI,
   ingredient,
   nature,
   PIKACHU,
@@ -300,6 +301,28 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
     if (CarrySizeUtils.baseCarrySize(PIKACHU) !== CarrySizeUtils.baseCarrySize(RAICHU)) {
       expect(result.carrySize).not.toBe(existingInstance.carrySize)
     }
+  })
+
+  it('should force shiny to false when the new Pokemon species is shiny-locked', () => {
+    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+      pokemon: PIKACHU,
+      shiny: true
+    })
+
+    const result = PokemonInstanceUtils.createPokemonInstanceWithPreservedAttributes(DARKRAI, existingInstance)
+
+    expect(result.shiny).toBe(false)
+  })
+
+  it('should preserve shiny when the new Pokemon species is not shiny-locked', () => {
+    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+      pokemon: PIKACHU,
+      shiny: true
+    })
+
+    const result = PokemonInstanceUtils.createPokemonInstanceWithPreservedAttributes(RAICHU, existingInstance)
+
+    expect(result.shiny).toBe(true)
   })
 
   it('should generate new gender for new Pokemon species', () => {

--- a/frontend/src/services/utils/pokemon-instance-utils.ts
+++ b/frontend/src/services/utils/pokemon-instance-utils.ts
@@ -58,6 +58,7 @@ class PokemonInstanceUtilsImpl {
     const instance = {
       ...existingInstance,
       pokemon: newPokemon,
+      shiny: newPokemon.shinyLocked ? false : existingInstance.shiny,
       ingredients: [
         { ...newPokemon.ingredient0[0], level: 0 },
         { ...newPokemon.ingredient30[0], level: 30 },


### PR DESCRIPTION
## Summary
- Add an optional `shinyLocked` flag to `Pokemon` and set it on Darkrai (mythicals/certain pokemon can't be shiny in-game)
- Hide the shiny toggle button in the pokemon editor for shiny-locked species, and no-op `toggleShiny()` as a guard
- Force `shiny` back to `false` when swapping an existing team member to a shiny-locked species via `createPokemonInstanceWithPreservedAttributes`