### PR TITLE
fix: set Mew's egg/herb/blank default ingredients

### DIFF
--- a/common/src/types/pokemon/__snapshots__/pokemon.test.ts.snap
+++ b/common/src/types/pokemon/__snapshots__/pokemon.test.ts.snap
@@ -19070,19 +19070,19 @@ exports[`COMPLETE_POKEDEX > shall not change MEW unexpectedly 1`] = `
     {
       "amount": 2,
       "ingredient": {
-        "longName": "Large Leek",
-        "name": "Leek",
-        "taxedValue": 100.1,
-        "value": 185,
+        "longName": "Fancy Egg",
+        "name": "Egg",
+        "taxedValue": 38.7,
+        "value": 115,
       },
     },
     {
       "amount": 2,
       "ingredient": {
-        "longName": "Fancy Egg",
-        "name": "Egg",
-        "taxedValue": 38.7,
-        "value": 115,
+        "longName": "Large Leek",
+        "name": "Leek",
+        "taxedValue": 100.1,
+        "value": 185,
       },
     },
     {
@@ -19133,6 +19133,15 @@ exports[`COMPLETE_POKEDEX > shall not change MEW unexpectedly 1`] = `
   ],
   "ingredient30": [
     {
+      "amount": 4,
+      "ingredient": {
+        "longName": "Fiery Herb",
+        "name": "Herb",
+        "taxedValue": 49.4,
+        "value": 130,
+      },
+    },
+    {
       "amount": 3,
       "ingredient": {
         "longName": "Large Leek",
@@ -19148,15 +19157,6 @@ exports[`COMPLETE_POKEDEX > shall not change MEW unexpectedly 1`] = `
         "name": "Egg",
         "taxedValue": 38.7,
         "value": 115,
-      },
-    },
-    {
-      "amount": 4,
-      "ingredient": {
-        "longName": "Fiery Herb",
-        "name": "Herb",
-        "taxedValue": 49.4,
-        "value": 130,
       },
     },
     {

--- a/common/src/types/pokemon/all-pokemon.ts
+++ b/common/src/types/pokemon/all-pokemon.ts
@@ -34,8 +34,8 @@ export const MEW: Pokemon = createAllSpecialist({
   remainingEvolutions: 0,
   ingredients: {
     ingredient0: [
-      { amount: 2, ingredient: LARGE_LEEK },
       { amount: 2, ingredient: FANCY_EGG },
+      { amount: 2, ingredient: LARGE_LEEK },
       { amount: 2, ingredient: FIERY_HERB },
       { amount: 2, ingredient: BEAN_SAUSAGE },
       { amount: 2, ingredient: PURE_OIL },
@@ -43,9 +43,9 @@ export const MEW: Pokemon = createAllSpecialist({
       { amount: 2, ingredient: GLOSSY_AVOCADO }
     ],
     ingredient30: [
+      { amount: 4, ingredient: FIERY_HERB },
       { amount: 3, ingredient: LARGE_LEEK },
       { amount: 4, ingredient: FANCY_EGG },
-      { amount: 4, ingredient: FIERY_HERB },
       { amount: 4, ingredient: BEAN_SAUSAGE },
       { amount: 4, ingredient: PURE_OIL },
       { amount: 5, ingredient: GREENGRASS_SOYBEANS },


### PR DESCRIPTION
## Summary
- The Mew PR (#merged) reordered `ingredient0`/`ingredient30` back to Large Leek first during merge conflict resolution, undoing the intended Egg/Herb/blank default (matching Darkrai's default-ordering convention: index 0 of each level array is the default shown for a new instance).
- Restores `ingredient0[0]` = Fancy Egg and `ingredient30[0]` = Fiery Herb. `ingredient60[0]` (blank/`LOCKED_INGREDIENT`) was unaffected and stays as-is.

## Test plan
- [x] `common` test suite passes (snapshot updated to reflect the new default order)
- [x] `backend` test suite passes (no dependency on Mew's ingredient order)
- [x] `frontend` test suite passes
- [x] eslint / prettier / tsc clean